### PR TITLE
Fix/fix crash callbacks on 404

### DIFF
--- a/MobileCenter/MobileCenter/Internals/Channel/MSChannel.h
+++ b/MobileCenter/MobileCenter/Internals/Channel/MSChannel.h
@@ -51,8 +51,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Delete all logs from storage.
+ *
+ * @param error Error describing why all logs are deleted.
  */
-- (void)deleteAllLogs;
+- (void)deleteAllLogsWithError:(NSError *)error;
 
 /**
  *  Add delegate.

--- a/MobileCenter/MobileCenter/Internals/Channel/MSLogManagerDefault.m
+++ b/MobileCenter/MobileCenter/Internals/Channel/MSLogManagerDefault.m
@@ -120,12 +120,6 @@ static char *const MSlogsDispatchQueue = "com.microsoft.azure.mobile.mobilecente
   return (channel) ? channel : [self createChannelForPriority:priority];
 }
 
-#pragma mark - Storage
-
-- (void)deleteLogsForPriority:(MSPriority)priority {
-  [[self channelForPriority:priority] deleteAllLogs];
-}
-
 #pragma mark - Enable / Disable
 
 - (void)setEnabled:(BOOL)isEnabled andDeleteDataOnDisabled:(BOOL)deleteData {
@@ -133,17 +127,19 @@ static char *const MSlogsDispatchQueue = "com.microsoft.azure.mobile.mobilecente
     self.enabled = isEnabled;
 
     // Propagate to sender.
+    // Sender will in turn propagates to its channel delegates.
     [self.sender setEnabled:isEnabled andDeleteDataOnDisabled:deleteData];
 
-    // Propagate to channels.
-    for (NSNumber *priority in self.channels) {
-      [self.channels[priority] setEnabled:isEnabled andDeleteDataOnDisabled:NO];
-    }
-
-    // If requested, delete any remaining logs (e.g., even logs from not started services).
+    // If requested, also delete logs from not started services.
     if (!isEnabled && deleteData) {
-      for (int priority = 0; priority < kMSPriorityCount; priority++) {
-        [self deleteLogsForPriority:priority];
+      NSArray<NSNumber *> *runningPriorities = self.channels.allKeys;
+      for (NSInteger priority = 0; priority < kMSPriorityCount; priority++) {
+        if (![runningPriorities containsObject:@(priority)]) {
+          NSError *error = [NSError errorWithDomain:kMSConnectionErrorDomain
+                                               code:kMSConnectionSuspendedErrorCode
+                                           userInfo:@{NSLocalizedDescriptionKey : kMSConnectionSuspendedErrorDesc}];
+          [[self channelForPriority:priority] deleteAllLogsWithError:error];
+        }
       }
     }
   }

--- a/MobileCenter/MobileCenter/Internals/Storage/MSFileStorage.m
+++ b/MobileCenter/MobileCenter/Internals/Storage/MSFileStorage.m
@@ -85,7 +85,7 @@ static NSUInteger const MSDefaultLogCountLimit = 50;
   [self deleteFile:[bucket fileWithId:logsId] fromBucket:bucket];
 }
 
-- (NSArray<MSLog> *)deleteFile:(MSFile *)file fromBucket:(MSStorageBucket *)aBucket {
+- (NSArray<MSLog> *)deleteFile:(MSFile *)file fromBucket:(MSStorageBucket *)bucket {
   NSMutableArray<MSLog> *deletedLogs = [NSMutableArray<MSLog> new];
   if (file) {
 
@@ -97,7 +97,7 @@ static NSUInteger const MSDefaultLogCountLimit = 50;
 
     // Wipe it.
     [MSFileUtil deleteFile:file];
-    [aBucket removeFile:file];
+    [bucket removeFile:file];
   }
   return deletedLogs;
 }

--- a/MobileCenter/MobileCenter/Internals/Storage/MSFileStorage.m
+++ b/MobileCenter/MobileCenter/Internals/Storage/MSFileStorage.m
@@ -1,6 +1,6 @@
 #import "MSFile.h"
-#import "MSFileUtil.h"
 #import "MSFileStorage.h"
+#import "MSFileUtil.h"
 #import "MSLogger.h"
 #import "MSMobileCenterInternal.h"
 #import "MSUtil.h"
@@ -61,7 +61,10 @@ static NSUInteger const MSDefaultLogCountLimit = 50;
   [MSFileUtil writeData:logsData toFile:bucket.currentFile];
 }
 
-- (void)deleteLogsForStorageKey:(NSString *)storageKey {
+- (NSArray<MSLog> *)deleteLogsForStorageKey:(NSString *)storageKey {
+
+  // Cache deleted logs
+  NSMutableArray<MSLog> *deletedLogs = [NSMutableArray<MSLog> new];
 
   // Remove all files from the bucket.
   MSStorageBucket *bucket = self.buckets[storageKey];
@@ -69,24 +72,34 @@ static NSUInteger const MSDefaultLogCountLimit = 50;
 
   // Delete all files.
   for (MSFile *file in allFiles) {
-    if (file) {
-      [MSFileUtil deleteFile:file];
-      [bucket removeFile:file];
-    }
+    [deletedLogs addObjectsFromArray:[self deleteFile:file fromBucket:bucket]];
   }
 
   // Get ready for next time.
   [self renewCurrentFileForStorageKey:storageKey];
+  return deletedLogs;
 }
 
 - (void)deleteLogsForId:(NSString *)logsId withStorageKey:(NSString *)storageKey {
   MSStorageBucket *bucket = self.buckets[storageKey];
-  MSFile *file = [bucket fileWithId:logsId];
+  [self deleteFile:[bucket fileWithId:logsId] fromBucket:bucket];
+}
 
+- (NSArray<MSLog> *)deleteFile:(MSFile *)file fromBucket:(MSStorageBucket *)aBucket {
+  NSMutableArray<MSLog> *deletedLogs = [NSMutableArray<MSLog> new];
   if (file) {
+
+    // Cache logs from file.
+    NSArray<MSLog> *logs = [NSKeyedUnarchiver unarchiveObjectWithData:[MSFileUtil dataForFile:file]];
+    if (logs) {
+      [deletedLogs addObjectsFromArray:logs];
+    }
+
+    // Wipe it.
     [MSFileUtil deleteFile:file];
-    [bucket removeFile:file];
+    [aBucket removeFile:file];
   }
+  return deletedLogs;
 }
 
 - (BOOL)loadLogsForStorageKey:(NSString *)storageKey withCompletion:(nullable MSLoadDataCompletionBlock)completion {

--- a/MobileCenter/MobileCenter/Internals/Storage/MSStorage.h
+++ b/MobileCenter/MobileCenter/Internals/Storage/MSStorage.h
@@ -35,41 +35,42 @@ typedef void (^MSLoadDataCompletionBlock)(BOOL succeeded, NSArray<MSLog> *logArr
 /**
  * Writes a log to the file system.
  *
- * param log The log item that should be written to disk
- * param storageKey The key used for grouping
+ * @param log The log item that should be written to disk
+ * @param storageKey The key used for grouping
  */
 - (void)saveLog:(id<MSLog>)log withStorageKey:(NSString *)storageKey;
 
 /**
  * Delete logs related to given storage key from the file system.
  *
- * param storageKey The key used for grouping.
+ * @param storageKey The key used for grouping.
+ * @return the list of deleted logs.
  */
-- (void)deleteLogsForStorageKey:(NSString *)storageKey;
+- (NSArray<MSLog> *)deleteLogsForStorageKey:(NSString *)storageKey;
 
 /**
  * Delete a log from the file system.
  *
- * param log The log item that should be deleted from disk.
- * param storageKey The key used for grouping.
+ * @param log The log item that should be deleted from disk.
+ * @param storageKey The key used for grouping.
  */
 - (void)deleteLogsForId:(NSString *)logsId withStorageKey:(NSString *)storageKey;
 
 /**
  * Returns the most recent logs for a given storage key.
  *
- * param storageKey The key used for grouping.
+ * @param storageKey The key used for grouping.
  *
  * @return a list of logs.
  */
 - (BOOL)loadLogsForStorageKey:(NSString *)storageKey withCompletion:(nullable MSLoadDataCompletionBlock)completion;
 
 /**
- *  FIXME: The number of logs per batch and the number of logs per files are currently tied together. The storage loads
+ * FIXME: The number of logs per batch and the number of logs per files are currently tied together. The storage loads
  * what's contained in the available file and this could be higher than the batch max size going to be sent. To mitigate
  * this kind of scenario the file is closed when the max size of the log batch is reached.
  *
- *  @param storageKey The key used for grouping.
+ * @param storageKey The key used for grouping.
  */
 - (void)closeBatchWithStorageKey:(NSString *)storageKey;
 

--- a/MobileCenter/MobileCenter/Internals/Utils/MSConstants+Internal.h
+++ b/MobileCenter/MobileCenter/Internals/Utils/MSConstants+Internal.h
@@ -9,10 +9,17 @@
 // Device manufacturer
 static NSString *const kMSDeviceManufacturer = @"Apple";
 
-// API Error
-static NSString *const kMSDefaultApiErrorDomain = @"MSDefaultApiErrorDomain";
+// Error domains
+static NSString *const kMSDefaultApiErrorDomain = @"com.microsoft.azure.mobile.mobilecenter.defaultapi";
+static NSString *const kMSConnectionErrorDomain = @"com.microsoft.azure.mobile.mobilecenter.connection";
+
+// Error codes
 static NSInteger const kMSDefaultApiMissingParamErrorCode = 234513;
+static NSInteger const kMSConnectionSuspendedErrorCode = 1;
 static NSInteger const kMSHttpErrorCodeMissingParameter = 422;
+
+// Error descriptions
+static NSString const *kMSConnectionSuspendedErrorDesc = @"Connection suspended with log deletion.";
 
 // Channel priorities, check the kMSPriorityCount if you add a new value.
 typedef NS_ENUM(NSInteger, MSPriority) { MSPriorityDefault, MSPriorityBackground, MSPriorityHigh };

--- a/MobileCenter/MobileCenter/Internals/Utils/MSConstants+Internal.h
+++ b/MobileCenter/MobileCenter/Internals/Utils/MSConstants+Internal.h
@@ -19,7 +19,7 @@ static NSInteger const kMSConnectionSuspendedErrorCode = 1;
 static NSInteger const kMSHttpErrorCodeMissingParameter = 422;
 
 // Error descriptions
-static NSString const *kMSConnectionSuspendedErrorDesc = @"Connection suspended with log deletion.";
+static NSString const *kMSConnectionSuspendedErrorDesc = @"Cancelled, connection suspended with log deletion.";
 
 // Channel priorities, check the kMSPriorityCount if you add a new value.
 typedef NS_ENUM(NSInteger, MSPriority) { MSPriorityDefault, MSPriorityBackground, MSPriorityHigh };

--- a/MobileCenter/MobileCenterTests/MSChannelDefaultTests.m
+++ b/MobileCenter/MobileCenterTests/MSChannelDefaultTests.m
@@ -7,6 +7,7 @@
 #import "MSChannelConfiguration.h"
 #import "MSChannelDefault.h"
 #import "MSChannelDelegate.h"
+#import "MSUtil.h"
 
 static NSString *const kMSTestPriorityName = @"Prio";
 
@@ -43,9 +44,9 @@ static NSString *const kMSTestPriorityName = @"Prio";
   _storageMock = OCMProtocolMock(@protocol(MSStorage));
   _senderMock = OCMProtocolMock(@protocol(MSSender));
   _sut = [[MSChannelDefault alloc] initWithSender:_senderMock
-                                           storage:_storageMock
-                                     configuration:_configMock
-                                 logsDispatchQueue:_logsDispatchQueue];
+                                          storage:_storageMock
+                                    configuration:_configMock
+                                logsDispatchQueue:_logsDispatchQueue];
 }
 
 - (void)tearDown {
@@ -69,9 +70,9 @@ static NSString *const kMSTestPriorityName = @"Prio";
   // If
   [self initChannelEndJobExpectation];
   MSChannelConfiguration *config = [[MSChannelConfiguration alloc] initWithPriorityName:kMSTestPriorityName
-                                                                            flushInterval:5
-                                                                           batchSizeLimit:10
-                                                                      pendingBatchesLimit:3];
+                                                                          flushInterval:5
+                                                                         batchSizeLimit:10
+                                                                    pendingBatchesLimit:3];
   self.sut.configuration = config;
   int itemsToAdd = 3;
 
@@ -96,9 +97,9 @@ static NSString *const kMSTestPriorityName = @"Prio";
   // If
   [self initChannelEndJobExpectation];
   MSChannelConfiguration *config = [[MSChannelConfiguration alloc] initWithPriorityName:kMSTestPriorityName
-                                                                            flushInterval:0.0
-                                                                           batchSizeLimit:3
-                                                                      pendingBatchesLimit:3];
+                                                                          flushInterval:0.0
+                                                                         batchSizeLimit:3
+                                                                    pendingBatchesLimit:3];
   _sut.configuration = config;
   int itemsToAdd = 3;
   XCTestExpectation *expectation = [self expectationWithDescription:@"All items enqueued"];
@@ -154,14 +155,14 @@ static NSString *const kMSTestPriorityName = @"Prio";
         loadCallback(YES, ((NSArray<MSLog> *)@[ log ]), [@(currentBatchId++) stringValue]);
       });
   MSChannelConfiguration *config = [[MSChannelConfiguration alloc] initWithPriorityName:kMSTestPriorityName
-                                                                            flushInterval:0.0
-                                                                           batchSizeLimit:1
-                                                                      pendingBatchesLimit:expectedMaxPendingBatched];
+                                                                          flushInterval:0.0
+                                                                         batchSizeLimit:1
+                                                                    pendingBatchesLimit:expectedMaxPendingBatched];
   _sut.configuration = config;
   MSChannelDefault *sut = [[MSChannelDefault alloc] initWithSender:senderMock
-                                                             storage:storageMock
-                                                       configuration:config
-                                                   logsDispatchQueue:self.logsDispatchQueue];
+                                                           storage:storageMock
+                                                     configuration:config
+                                                 logsDispatchQueue:self.logsDispatchQueue];
 
   // When
   for (int i = 1; i <= expectedMaxPendingBatched + 1; i++) {
@@ -225,14 +226,14 @@ static NSString *const kMSTestPriorityName = @"Prio";
 
   // Configure channel.
   MSChannelConfiguration *config = [[MSChannelConfiguration alloc] initWithPriorityName:kMSTestPriorityName
-                                                                            flushInterval:0.0
-                                                                           batchSizeLimit:1
-                                                                      pendingBatchesLimit:1];
+                                                                          flushInterval:0.0
+                                                                         batchSizeLimit:1
+                                                                    pendingBatchesLimit:1];
   _sut.configuration = config;
   MSChannelDefault *sut = [[MSChannelDefault alloc] initWithSender:senderMock
-                                                             storage:storageMock
-                                                       configuration:config
-                                                   logsDispatchQueue:dispatch_get_main_queue()];
+                                                           storage:storageMock
+                                                     configuration:config
+                                                 logsDispatchQueue:dispatch_get_main_queue()];
 
   /**
    * When
@@ -291,14 +292,14 @@ static NSString *const kMSTestPriorityName = @"Prio";
       loadLogsForStorageKey:kMSTestPriorityName
              withCompletion:([OCMArg invokeBlockWithArgs:@YES, ((NSArray<MSLog> *)@[ log ]), @"1", nil])]);
   MSChannelConfiguration *config = [[MSChannelConfiguration alloc] initWithPriorityName:kMSTestPriorityName
-                                                                            flushInterval:0.0
-                                                                           batchSizeLimit:1
-                                                                      pendingBatchesLimit:10];
+                                                                          flushInterval:0.0
+                                                                         batchSizeLimit:1
+                                                                    pendingBatchesLimit:10];
   _sut.configuration = config;
   MSChannelDefault *sut = [[MSChannelDefault alloc] initWithSender:senderMock
-                                                             storage:storageMock
-                                                       configuration:config
-                                                   logsDispatchQueue:dispatch_get_main_queue()];
+                                                           storage:storageMock
+                                                     configuration:config
+                                                 logsDispatchQueue:dispatch_get_main_queue()];
   /**
    * When
    */
@@ -350,7 +351,6 @@ static NSString *const kMSTestPriorityName = @"Prio";
 
                                  // Check that logs as been requested for deletion and that there is no batch left.
                                  OCMVerify([storageMock deleteLogsForStorageKey:kMSTestPriorityName]);
-                                 assertThatUnsignedLong(sut.pendingBatchIds.count, equalToInt(0));
                                  if (error) {
                                    XCTFail(@"Expectation Failed with error: %@", error);
                                  }
@@ -361,17 +361,17 @@ static NSString *const kMSTestPriorityName = @"Prio";
 
   // If
   [self initChannelEndJobExpectation];
-  id <MSChannelDelegate> delegateMock = OCMProtocolMock(@protocol(MSChannelDelegate));
-  id <MSLog> log = [MSAbstractLog new];
-  
-  #pragma clang diagnostic push
-  #pragma clang diagnostic ignored "-Wnonnull"
+  id<MSChannelDelegate> delegateMock = OCMProtocolMock(@protocol(MSChannelDelegate));
+  id<MSLog> log = [MSAbstractLog new];
+
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wnonnull"
   MSChannelDefault *sut = [[MSChannelDefault alloc] initWithSender:nil
                                                            storage:nil
                                                      configuration:nil
                                                  logsDispatchQueue:dispatch_get_main_queue()];
-  #pragma clang diagnostic pop
-  
+#pragma clang diagnostic pop
+
   // When
   [sut addDelegate:delegateMock];
   [sut setEnabled:NO andDeleteDataOnDisabled:YES];
@@ -385,6 +385,112 @@ static NSString *const kMSTestPriorityName = @"Prio";
                                  // Check the callbacks were invoked for logs.
                                  OCMVerify([delegateMock channel:sut willSendLog:log]);
                                  OCMVerify([delegateMock channel:sut didFailSendingLog:log withError:anything()]);
+                                 if (error) {
+                                   XCTFail(@"Expectation Failed with error: %@", error);
+                                 }
+                               }];
+}
+
+- (void)testDelegateCalledOnNonRecouverableError {
+
+  /**
+   * If
+   */
+  [self initChannelEndJobExpectation];
+  __block MSSendAsyncCompletionHandler senderBlock;
+  __block NSArray<MSAbstractLog *> *expectedLogs = @[ [MSAbstractLog new], [MSAbstractLog new], [MSAbstractLog new] ];
+  __block NSMutableArray<MSLog> *failedForwardedLogs = [NSMutableArray<MSLog> new];
+  __block NSMutableArray<MSLog> *willSendForwardedLogs = [NSMutableArray<MSLog> new];
+  id<MSChannelDelegate> delegateMock = OCMProtocolMock(@protocol(MSChannelDelegate));
+
+  // Stub the sender for that log.
+  id senderMock = OCMProtocolMock(@protocol(MSSender));
+  OCMStub([senderMock sendAsync:[OCMArg any] completionHandler:[OCMArg any]]).andDo(^(NSInvocation *invocation) {
+
+    // Get sender bloc for later call.
+    [invocation retainArguments];
+    [invocation getArgument:&senderBlock atIndex:3];
+  });
+
+  // Stub the storage load for that log.
+  id storageMock = OCMProtocolMock(@protocol(MSStorage));
+  OCMStub([storageMock loadLogsForStorageKey:kMSTestPriorityName withCompletion:([OCMArg any])])
+      .andDo(^(NSInvocation *invocation) {
+        MSLoadDataCompletionBlock loadCallback;
+
+        // Get sender bloc for later call.
+        [invocation getArgument:&loadCallback atIndex:3];
+
+        // Mock load of the first log.
+        loadCallback(YES, ((NSArray<MSLog> *)@[ expectedLogs[0] ]), @"0");
+      });
+
+  // Stub the storage to return deleted values.
+  OCMStub([storageMock deleteLogsForStorageKey:[OCMArg any]]).andDo(^(NSInvocation *invocation) {
+    NSMutableArray<MSLog> *deletedLogs = [expectedLogs mutableCopy];
+    [deletedLogs removeObjectAtIndex:0];
+
+    // Return the supposed deleted logs.
+    [invocation setReturnValue:&deletedLogs];
+    [invocation retainArguments];
+  });
+
+  // Configure channel.
+  MSChannelConfiguration *config = [[MSChannelConfiguration alloc] initWithPriorityName:kMSTestPriorityName
+                                                                          flushInterval:0.0
+                                                                         batchSizeLimit:1
+                                                                    pendingBatchesLimit:1];
+  self.sut = [[MSChannelDefault alloc] initWithSender:senderMock
+                                              storage:storageMock
+                                        configuration:config
+                                    logsDispatchQueue:self.logsDispatchQueue];
+  [self.sut addDelegate:delegateMock];
+
+  // Monitor will send callback.
+  OCMStub([delegateMock channel:self.sut willSendLog:[OCMArg any]]).andDo(^(NSInvocation *invocation) {
+    id<MSLog> log;
+    [invocation getArgument:&log atIndex:3];
+    [willSendForwardedLogs addObject:log];
+  });
+
+  // Monitor did fail callback.
+  OCMStub([delegateMock channel:self.sut didFailSendingLog:[OCMArg any] withError:[OCMArg any]])
+      .andDo(^(NSInvocation *invocation) {
+        id<MSLog> log;
+        [invocation getArgument:&log atIndex:3];
+        [failedForwardedLogs addObject:log];
+      });
+
+  // Stub sender suspended method.
+  OCMStub([senderMock setEnabled:NO andDeleteDataOnDisabled:YES]).andDo(^(NSInvocation *invocation) {
+    [self.sut sender:senderMock didSetEnabled:(NO) andDeleteDataOnDisabled:YES];
+    [self enqueueChannelEndJobExpectation];
+  });
+
+  // Enqueue items to the channel.
+  for (id<MSLog> log in expectedLogs) {
+    log.sid = MS_UUID_STRING;
+    [self.sut enqueueItem:log withCompletion:nil];
+  }
+
+  /**
+   * When
+   */
+
+  // Forward a non recoverable error.
+  dispatch_async(self.logsDispatchQueue, ^{
+    senderBlock([@(0) stringValue], nil, MSHTTPCodesNo404NotFound);
+  });
+
+  /**
+   * Then
+   */
+  [self waitForExpectationsWithTimeout:1
+                               handler:^(NSError *error) {
+
+                                 // Forwarded logs are equal to expected logs.
+                                 assertThatBool([willSendForwardedLogs isEqualToArray:expectedLogs], isTrue());
+                                 assertThatBool([failedForwardedLogs isEqualToArray:expectedLogs], isTrue());
                                  if (error) {
                                    XCTFail(@"Expectation Failed with error: %@", error);
                                  }

--- a/MobileCenter/MobileCenterTests/MSHttpSenderTests.m
+++ b/MobileCenter/MobileCenterTests/MSHttpSenderTests.m
@@ -349,7 +349,6 @@ static NSString *const kMSAppSecret = @"mockAppSecret";
   // Mock the call to intercept the retry.
   MSRetriableCall *mockedCall = OCMPartialMock(self.sut.pendingCalls[@"1"]);
   OCMStub([mockedCall sender:self.sut callCompletedWithStatus:MSHTTPCodesNo500InternalServerError error:[OCMArg any]]).andForwardToRealObject().andDo(^(NSInvocation *invocation){
-           NSLog(@"TEST1: %@", ((MSRetriableCall*)self.sut.pendingCalls[@"1"]).timerSource);//TODO remove
            [responseReceivedExcpectation fulfill];
   });
   self.sut.pendingCalls[@"1"] = mockedCall;

--- a/Puppet/Puppet/AppDelegate.m
+++ b/Puppet/Puppet/AppDelegate.m
@@ -128,7 +128,7 @@
 }
 
 - (void)crashes:(MSCrashes *)crashes didFailSendingErrorReport:(MSErrorReport *)errorReport withError:(NSError *)error {
-  NSLog(@"Did fail sending report with: %@, and error %@",
+  NSLog(@"Did fail sending report with: %@, and error: %@",
           errorReport.exceptionReason,
           error.localizedDescription);
 }


### PR DESCRIPTION
    Fix other non sent crash callback not triggered on HTTP fatal error
    
    * Callback didFailSendingLog now also called on logs stored and but not sent in case of non retriable error
    * Optimize channel enabling/disabling process within log manager
    * Return deleted logs while deleting logs from a storage key
    * Add unit test