### PR TITLE
Forward http status code to crash sending failure callback

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This version has bug fixes.
 
 ### MobileCenter
 
+* **[Bug]** Fix crash sending failure callback, http status code now included in forwarded error.
 * **[Bug]** Fix http tasks cancelled when expected to be suspended.
 
 ___

--- a/MobileCenter/MobileCenter.xcodeproj/project.pbxproj
+++ b/MobileCenter/MobileCenter.xcodeproj/project.pbxproj
@@ -52,7 +52,7 @@
 		387C75961D64EE1900D68CC1 /* MSServiceAbstractTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 387C75951D64EE1900D68CC1 /* MSServiceAbstractTest.m */; };
 		387C76DA1D677EC100D68CC1 /* MSServiceAbstractPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 387C76D91D677EC100D68CC1 /* MSServiceAbstractPrivate.h */; };
 		387C76FD1D6C9CF100D68CC1 /* MSServiceAbstract.h in Headers */ = {isa = PBXBuildFile; fileRef = 387C76FC1D6C9CF100D68CC1 /* MSServiceAbstract.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		3889932F1E29829700C27B36 /* MSMobileCenterErrors.h in Headers */ = {isa = PBXBuildFile; fileRef = 3889932E1E29829700C27B36 /* MSMobileCenterErrors.h */; };
+		3889932F1E29829700C27B36 /* MSMobileCenterErrors.h in Headers */ = {isa = PBXBuildFile; fileRef = 3889932E1E29829700C27B36 /* MSMobileCenterErrors.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3889933A1E29B26D00C27B36 /* MSMobileCenterErrors.m in Sources */ = {isa = PBXBuildFile; fileRef = 388993391E29B26D00C27B36 /* MSMobileCenterErrors.m */; };
 		389124281DC7ABB600197086 /* MSRetriableCallPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 389124271DC7ABB600197086 /* MSRetriableCallPrivate.h */; };
 		38CA60ED1D949F5000B82420 /* MSFileStorage.m in Sources */ = {isa = PBXBuildFile; fileRef = 6E40D4621D2700000046D85B /* MSFileStorage.m */; };

--- a/MobileCenter/MobileCenter.xcodeproj/project.pbxproj
+++ b/MobileCenter/MobileCenter.xcodeproj/project.pbxproj
@@ -52,6 +52,8 @@
 		387C75961D64EE1900D68CC1 /* MSServiceAbstractTest.m in Sources */ = {isa = PBXBuildFile; fileRef = 387C75951D64EE1900D68CC1 /* MSServiceAbstractTest.m */; };
 		387C76DA1D677EC100D68CC1 /* MSServiceAbstractPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 387C76D91D677EC100D68CC1 /* MSServiceAbstractPrivate.h */; };
 		387C76FD1D6C9CF100D68CC1 /* MSServiceAbstract.h in Headers */ = {isa = PBXBuildFile; fileRef = 387C76FC1D6C9CF100D68CC1 /* MSServiceAbstract.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3889932F1E29829700C27B36 /* MSMobileCenterErrors.h in Headers */ = {isa = PBXBuildFile; fileRef = 3889932E1E29829700C27B36 /* MSMobileCenterErrors.h */; };
+		3889933A1E29B26D00C27B36 /* MSMobileCenterErrors.m in Sources */ = {isa = PBXBuildFile; fileRef = 388993391E29B26D00C27B36 /* MSMobileCenterErrors.m */; };
 		389124281DC7ABB600197086 /* MSRetriableCallPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 389124271DC7ABB600197086 /* MSRetriableCallPrivate.h */; };
 		38CA60ED1D949F5000B82420 /* MSFileStorage.m in Sources */ = {isa = PBXBuildFile; fileRef = 6E40D4621D2700000046D85B /* MSFileStorage.m */; };
 		38E1B67A1DDE3FDF000EFED1 /* MSMobileCenterPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 38E1B6791DDE3FDF000EFED1 /* MSMobileCenterPrivate.h */; };
@@ -184,6 +186,8 @@
 		387C75951D64EE1900D68CC1 /* MSServiceAbstractTest.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = MSServiceAbstractTest.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		387C76D91D677EC100D68CC1 /* MSServiceAbstractPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MSServiceAbstractPrivate.h; sourceTree = "<group>"; };
 		387C76FC1D6C9CF100D68CC1 /* MSServiceAbstract.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MSServiceAbstract.h; sourceTree = "<group>"; };
+		3889932E1E29829700C27B36 /* MSMobileCenterErrors.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MSMobileCenterErrors.h; sourceTree = "<group>"; };
+		388993391E29B26D00C27B36 /* MSMobileCenterErrors.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSMobileCenterErrors.m; sourceTree = "<group>"; };
 		389124271DC7ABB600197086 /* MSRetriableCallPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MSRetriableCallPrivate.h; sourceTree = "<group>"; };
 		38E1B6791DDE3FDF000EFED1 /* MSMobileCenterPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MSMobileCenterPrivate.h; sourceTree = "<group>"; };
 		38EAD9AB1DA6A8C500CE6030 /* MSEnable.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MSEnable.h; sourceTree = "<group>"; };
@@ -347,6 +351,8 @@
 				6E0401561D1C9AAA0051BCFA /* MSMobileCenter.m */,
 				B2C3C18E1DB9864600CB83F7 /* MSWrapperSdk.h */,
 				B2C3C18F1DB9864600CB83F7 /* MSWrapperSdk.m */,
+				3889932E1E29829700C27B36 /* MSMobileCenterErrors.h */,
+				388993391E29B26D00C27B36 /* MSMobileCenterErrors.m */,
 				6E0401421D1C99AC0051BCFA /* Internals */,
 				6E0401821D1CAD810051BCFA /* Support */,
 			);
@@ -631,6 +637,7 @@
 				6E0401711D1C9E460051BCFA /* MSServiceInternal.h in Headers */,
 				35D0B7531DDFABFD003EACCD /* MSWrapperLogger.h in Headers */,
 				E88D170E1D36BB1700A5EA57 /* MSUtil.h in Headers */,
+				3889932F1E29829700C27B36 /* MSMobileCenterErrors.h in Headers */,
 				E84B8E321D235209006FD231 /* MSSender.h in Headers */,
 				E84B8E2E1D2351DB006FD231 /* MSLogManager.h in Headers */,
 				385AD9221D95898D008B354A /* MSServiceAbstractProtected.h in Headers */,
@@ -779,6 +786,7 @@
 				6EF628F51D371B1600CAFF64 /* MSChannelConfiguration.m in Sources */,
 				6E171B611D234717000DC480 /* MSLogContainer.m in Sources */,
 				B2C3C1911DB9864600CB83F7 /* MSDevice.m in Sources */,
+				3889933A1E29B26D00C27B36 /* MSMobileCenterErrors.m in Sources */,
 				E84B8E361D235226006FD231 /* MSHttpSender.m in Sources */,
 				E84B8E301D2351DB006FD231 /* MSLogManagerDefault.m in Sources */,
 				E8753D6F1D4BE53F00241513 /* MSSenderUtil.m in Sources */,

--- a/MobileCenter/MobileCenter/Internals/Channel/MSChannelDefault.m
+++ b/MobileCenter/MobileCenter/Internals/Channel/MSChannelDefault.m
@@ -4,6 +4,7 @@
 
 #import "MSChannelDefault.h"
 #import "MSConstants+Internal.h"
+#import "MSMobileCenterErrors.h"
 #import "MSMobileCenterInternal.h"
 
 /**
@@ -101,9 +102,9 @@
       return;
     } else if (self.discardLogs) {
       MSLogWarning([MSMobileCenter getLoggerTag], @"Channel disabled in log discarding mode, discard this log.");
-      NSError *error = [NSError errorWithDomain:kMSConnectionErrorDomain
-                                           code:kMSConnectionSuspendedErrorCode
-                                       userInfo:@{NSLocalizedDescriptionKey : kMSConnectionSuspendedErrorDesc}];
+      NSError *error = [NSError errorWithDomain:kMSMCErrorDomain
+                                           code:kMSMCConnectionSuspendedErrorCode
+                                       userInfo:@{NSLocalizedDescriptionKey : kMSMCConnectionSuspendedErrorDesc}];
       [self notifyFailureBeforeSendingForItem:item withError:error];
       return;
     }
@@ -291,9 +292,9 @@
     // Even if it's already disabled we might also want to delete logs this time.
     if (!isEnabled && deleteData) {
       MSLogDebug([MSMobileCenter getLoggerTag], @"Delete all logs.");
-      NSError *error = [NSError errorWithDomain:kMSConnectionErrorDomain
-                                           code:kMSConnectionSuspendedErrorCode
-                                       userInfo:@{NSLocalizedDescriptionKey : kMSConnectionSuspendedErrorDesc}];
+      NSError *error = [NSError errorWithDomain:kMSMCErrorDomain
+                                           code:kMSMCConnectionSuspendedErrorCode
+                                       userInfo:@{NSLocalizedDescriptionKey : kMSMCConnectionSuspendedErrorDesc}];
       [self deleteAllLogsWithErrorSync:error];
 
       // Reset states.

--- a/MobileCenter/MobileCenter/Internals/Channel/MSLogManagerDefault.m
+++ b/MobileCenter/MobileCenter/Internals/Channel/MSLogManagerDefault.m
@@ -4,6 +4,7 @@
 
 #import "MSChannelDefault.h"
 #import "MSLogManagerDefault.h"
+#import "MSMobileCenterErrors.h"
 #import "MobileCenter+Internal.h"
 
 static char *const MSlogsDispatchQueue = "com.microsoft.azure.mobile.mobilecenter.LogManagerQueue";
@@ -135,9 +136,9 @@ static char *const MSlogsDispatchQueue = "com.microsoft.azure.mobile.mobilecente
       NSArray<NSNumber *> *runningPriorities = self.channels.allKeys;
       for (NSInteger priority = 0; priority < kMSPriorityCount; priority++) {
         if (![runningPriorities containsObject:@(priority)]) {
-          NSError *error = [NSError errorWithDomain:kMSConnectionErrorDomain
-                                               code:kMSConnectionSuspendedErrorCode
-                                           userInfo:@{NSLocalizedDescriptionKey : kMSConnectionSuspendedErrorDesc}];
+          NSError *error = [NSError errorWithDomain:kMSMCErrorDomain
+                                               code:kMSMCConnectionSuspendedErrorCode
+                                           userInfo:@{NSLocalizedDescriptionKey : kMSMCConnectionSuspendedErrorDesc}];
           [[self channelForPriority:priority] deleteAllLogsWithError:error];
         }
       }

--- a/MobileCenter/MobileCenter/Internals/Sender/MSHttpSender.m
+++ b/MobileCenter/MobileCenter/Internals/Sender/MSHttpSender.m
@@ -2,9 +2,9 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  */
 
-#import "MSConstants+Internal.h"
 #import "MSHttpSender.h"
 #import "MSHttpSenderPrivate.h"
+#import "MSMobileCenterErrors.h"
 #import "MSMobileCenterInternal.h"
 #import "MSRetriableCall.h"
 #import "MSSenderDelegate.h"
@@ -70,11 +70,11 @@ static NSString *const kMSApiPath = @"/logs";
 
     // Verify container.
     if (!container || ![container isValid]) {
-      NSDictionary *userInfo = @{ NSLocalizedDescriptionKey : @"Invalid parameter'" };
+      NSDictionary *userInfo = @{NSLocalizedDescriptionKey : kMSMCLogInvalidContainerErrorDesc};
       NSError *error =
-          [NSError errorWithDomain:kMSDefaultApiErrorDomain code:kMSDefaultApiMissingParamErrorCode userInfo:userInfo];
+          [NSError errorWithDomain:kMSMCErrorDomain code:kMSMCLogInvalidContainerErrorCode userInfo:userInfo];
       MSLogError([MSMobileCenter getLoggerTag], @"%@", [error localizedDescription]);
-      handler(batchId, error, kMSDefaultApiMissingParamErrorCode);
+      handler(batchId, error, nil);
       return;
     }
 

--- a/MobileCenter/MobileCenter/Internals/Utils/MSConstants+Internal.h
+++ b/MobileCenter/MobileCenter/Internals/Utils/MSConstants+Internal.h
@@ -9,18 +9,6 @@
 // Device manufacturer
 static NSString *const kMSDeviceManufacturer = @"Apple";
 
-// Error domains
-static NSString *const kMSDefaultApiErrorDomain = @"com.microsoft.azure.mobile.mobilecenter.defaultapi";
-static NSString *const kMSConnectionErrorDomain = @"com.microsoft.azure.mobile.mobilecenter.connection";
-
-// Error codes
-static NSInteger const kMSDefaultApiMissingParamErrorCode = 234513;
-static NSInteger const kMSConnectionSuspendedErrorCode = 1;
-static NSInteger const kMSHttpErrorCodeMissingParameter = 422;
-
-// Error descriptions
-static NSString const *kMSConnectionSuspendedErrorDesc = @"Cancelled, connection suspended with log deletion.";
-
 // Http Headers + Query string.
 static NSString *const kMSHeaderAppSecretKey = @"App-Secret";
 static NSString *const kMSHeaderInstallIDKey = @"Install-ID";

--- a/MobileCenter/MobileCenter/MSMobileCenterErrors.h
+++ b/MobileCenter/MobileCenter/MSMobileCenterErrors.h
@@ -1,0 +1,29 @@
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+#pragma mark - Domain
+
+extern NSString *const kMSMCErrorDomain;
+
+#pragma mark - Log
+
+// Error codes
+NS_ENUM(NSInteger){kMSMCLogInvalidContainerErrorCode = 1};
+
+// Error descriptions
+extern NSString const *kMSMCLogInvalidContainerErrorDesc;
+
+#pragma mark - Connection
+
+// Error codes
+NS_ENUM(NSInteger){kMSMCConnectionSuspendedErrorCode = 100, kMSMCConnectionHttpErrorCode = 101};
+
+// Error descriptions
+extern NSString const *kMSMCConnectionHttpErrorDesc;
+extern NSString const *kMSMCConnectionSuspendedErrorDesc;
+
+// Error user info keys
+extern NSString const *kMSMCConnectionHttpCodeErrorKey;
+
+NS_ASSUME_NONNULL_END

--- a/MobileCenter/MobileCenter/MSMobileCenterErrors.m
+++ b/MobileCenter/MobileCenter/MSMobileCenterErrors.m
@@ -1,0 +1,21 @@
+#import "MSMobileCenterErrors.h"
+
+#define MS_MOBILE_CENTER_BASE_DOMAIN @"com.Microsoft.Azure.Mobile.MobileCenter."
+
+#pragma mark - Domain
+
+NSString *const kMSMCErrorDomain = MS_MOBILE_CENTER_BASE_DOMAIN @"ErrorDomain";
+
+#pragma mark - Log
+
+// Error descriptions
+NSString const *kMSMCLogInvalidContainerErrorDesc = @"Invalid log container";
+
+#pragma mark - Connection
+
+// Error descriptions
+NSString const *kMSMCConnectionHttpErrorDesc = @"An HTTP error occured.";
+NSString const *kMSMCConnectionSuspendedErrorDesc = @"Cancelled, connection suspended with log deletion.";
+
+// Error user info keys
+NSString const *kMSMCConnectionHttpCodeErrorKey = MS_MOBILE_CENTER_BASE_DOMAIN "HttpCodeKey";

--- a/MobileCenter/MobileCenter/MobileCenter.h
+++ b/MobileCenter/MobileCenter/MobileCenter.h
@@ -10,4 +10,6 @@
 #import "MSServiceAbstract.h"
 #import "MSMobileCenter.h"
 #import "MSWrapperSdk.h"
+#import "MSMobileCenterErrors.h"
+
 

--- a/MobileCenter/MobileCenterTests/Util/MSHttpTestUtil.h
+++ b/MobileCenter/MobileCenterTests/Util/MSHttpTestUtil.h
@@ -3,9 +3,10 @@
 
 @interface MSHttpTestUtil : NSObject
 
-+(void)stubHttp500Response;
-+(void)stubHttp200Response;
-+(void)stubNetworkDownResponse;
-+(void)stubLongTimeOutResponse;
++ (void)stubHttp500Response;
++ (void)stubHttp404Response;
++ (void)stubHttp200Response;
++ (void)stubNetworkDownResponse;
++ (void)stubLongTimeOutResponse;
 
 @end

--- a/MobileCenter/MobileCenterTests/Util/MSHttpTestUtil.m
+++ b/MobileCenter/MobileCenterTests/Util/MSHttpTestUtil.m
@@ -3,6 +3,7 @@
 
 static NSTimeInterval const kMSStubbedResponseTimeout = UID_MAX;
 static NSString *const kMSStub500Name = @"httpStub_500";
+static NSString *const kMSStub404Name = @"httpStub_404";
 static NSString *const kMSStub200Name = @"httpStub_200";
 static NSString *const kMSStubNetworkDownName = @"httpStub_NetworkDown";
 static NSString *const kMSStubLongResponseTimeOutName = @"httpStub_LongResponseTimeOut";
@@ -11,6 +12,10 @@ static NSString *const kMSStubLongResponseTimeOutName = @"httpStub_LongResponseT
 
 + (void)stubHttp500Response {
   [[self class] stubResponseWithCode:MSHTTPCodesNo500InternalServerError name:kMSStub500Name];
+}
+
++ (void)stubHttp404Response {
+  [[self class] stubResponseWithCode:MSHTTPCodesNo404NotFound name:kMSStub404Name];
 }
 
 + (void)stubHttp200Response {
@@ -34,7 +39,7 @@ static NSString *const kMSStubLongResponseTimeOutName = @"httpStub_LongResponseT
       .name = kMSStubLongResponseTimeOutName;
 }
 
-+ (void)stubResponseWithCode:(NSInteger)code name:(NSString *)aName {
++ (void)stubResponseWithCode:(NSInteger)code name:(NSString *)name {
   [OHHTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest *request) {
     return YES;
   }
@@ -43,17 +48,17 @@ static NSString *const kMSStubLongResponseTimeOutName = @"httpStub_LongResponseT
         responseStub.statusCode = (int)code;
         return responseStub;
       }]
-      .name = aName;
+      .name = name;
 }
 
-+ (void)stubResponseWithError:(NSError *)error name:(NSString *)aName {
++ (void)stubResponseWithError:(NSError *)error name:(NSString *)name {
   [OHHTTPStubs stubRequestsPassingTest:^BOOL(NSURLRequest *request) {
     return YES;
   }
       withStubResponse:^OHHTTPStubsResponse *(NSURLRequest *request) {
         return [OHHTTPStubsResponse responseWithError:error];
       }]
-      .name = aName;
+      .name = name;
 }
 
 @end


### PR DESCRIPTION
* Http status code added to the userInfo dict of the forwarded error
* Harmonize custom errors
* Match convention on custom errors
https://developer.apple.com/library/content/documentation/Cocoa/Conceptual/ErrorHandlingCocoa/CreateCustomizeNSError/CreateCustomizeNSError.html
https://developer.apple.com/library/content/documentation/Cocoa/Conceptual/ProgrammingWithObjectiveC/ErrorHandling/ErrorHandling.html
* Add/update unit tests