### PR TITLE
Feature/rename get logger tag

### DIFF
--- a/MobileCenter/MobileCenter/Internals/Channel/MSChannelDefault.m
+++ b/MobileCenter/MobileCenter/Internals/Channel/MSChannelDefault.m
@@ -98,10 +98,10 @@
 - (void)enqueueItem:(id<MSLog>)item withCompletion:(enqueueCompletionBlock)completion {
   dispatch_async(self.logsDispatchQueue, ^{
     if (!item) {
-      MSLogWarning([MSMobileCenter getLoggerTag], @"TelemetryItem was nil.");
+      MSLogWarning([MSMobileCenter logTag], @"TelemetryItem was nil.");
       return;
     } else if (self.discardLogs) {
-      MSLogWarning([MSMobileCenter getLoggerTag], @"Channel disabled in log discarding mode, discard this log.");
+      MSLogWarning([MSMobileCenter logTag], @"Channel disabled in log discarding mode, discard this log.");
       NSError *error = [NSError errorWithDomain:kMSMCErrorDomain
                                            code:kMSMCConnectionSuspendedErrorCode
                                        userInfo:@{NSLocalizedDescriptionKey : kMSMCConnectionSuspendedErrorDesc}];
@@ -110,7 +110,7 @@
     }
 
     // Save the log first.
-    MSLogDebug([MSMobileCenter getLoggerTag], @"Saving log, type: %@.", item.type);
+    MSLogDebug([MSMobileCenter logTag], @"Saving log, type: %@.", item.type);
     [self.storage saveLog:item withStorageKey:self.configuration.name];
     _itemsCount += 1;
     if (completion)
@@ -161,7 +161,7 @@
                    self.pendingBatchQueueFull = YES;
                  }
                  MSLogContainer *container = [[MSLogContainer alloc] initWithBatchId:batchId andLogs:logArray];
-                 MSLogDebug([MSMobileCenter getLoggerTag], @"Sending log(s), batch Id:%@, payload:\n %@", batchId,
+                 MSLogDebug([MSMobileCenter logTag], @"Sending log(s), batch Id:%@, payload:\n %@", batchId,
                             [container serializeLogWithPrettyPrinting:YES]);
 
                  // Notify delegates.
@@ -181,7 +181,7 @@
 
                            // Success.
                            if (statusCode == MSHTTPCodesNo200OK) {
-                             MSLogDebug([MSMobileCenter getLoggerTag], @"Log(s) sent with success, batch Id:%@.",
+                             MSLogDebug([MSMobileCenter logTag], @"Log(s) sent with success, batch Id:%@.",
                                         batchId);
 
                              // Notify delegates.
@@ -208,7 +208,7 @@
 
                            // Failure.
                            else {
-                             MSLogDebug([MSMobileCenter getLoggerTag],
+                             MSLogDebug([MSMobileCenter logTag],
                                         @"Log(s) sent with failure, batch Id:%@, status code:%lu", batchId,
                                         (unsigned long)statusCode);
 
@@ -232,7 +232,7 @@
                              }
                            }
                          } else
-                           MSLogWarning([MSMobileCenter getLoggerTag], @"Batch Id %@ not expected, ignore.", batchId);
+                           MSLogWarning([MSMobileCenter logTag], @"Batch Id %@ not expected, ignore.", batchId);
                        });
                      }];
                }
@@ -291,7 +291,7 @@
 
     // Even if it's already disabled we might also want to delete logs this time.
     if (!isEnabled && deleteData) {
-      MSLogDebug([MSMobileCenter getLoggerTag], @"Delete all logs.");
+      MSLogDebug([MSMobileCenter logTag], @"Delete all logs.");
       NSError *error = [NSError errorWithDomain:kMSMCErrorDomain
                                            code:kMSMCConnectionSuspendedErrorCode
                                        userInfo:@{NSLocalizedDescriptionKey : kMSMCConnectionSuspendedErrorDesc}];
@@ -310,7 +310,7 @@
 
 - (void)suspend {
   if (!self.suspended) {
-    MSLogDebug([MSMobileCenter getLoggerTag], @"Suspend channel.");
+    MSLogDebug([MSMobileCenter logTag], @"Suspend channel.");
     self.suspended = YES;
     [self resetTimer];
   }
@@ -318,7 +318,7 @@
 
 - (void)resume {
   if (self.suspended && self.enabled) {
-    MSLogDebug([MSMobileCenter getLoggerTag], @"Resume channel.");
+    MSLogDebug([MSMobileCenter logTag], @"Resume channel.");
     self.suspended = NO;
     self.discardLogs = NO;
     [self flushQueue];

--- a/MobileCenter/MobileCenter/Internals/MSMobileCenterInternal.h
+++ b/MobileCenter/MobileCenter/Internals/MSMobileCenterInternal.h
@@ -51,10 +51,10 @@ static NSString *const kMSMobileCenterIsEnabledKey = @"MSMobileCenterIsEnabled";
 - (BOOL)isEnabled;
 
 /**
- * Get the logger tag for the MobileCenter service.
+ * Get the log tag for the MobileCenter service.
  *
  * @return A name of logger tag for the MobileCenter service.
  */
-+ (NSString *)getLoggerTag;
++ (NSString *)logTag;
 
 @end

--- a/MobileCenter/MobileCenter/Internals/MSServiceAbstract.m
+++ b/MobileCenter/MobileCenter/Internals/MSServiceAbstract.m
@@ -56,7 +56,7 @@
 - (BOOL)canBeUsed {
   BOOL canBeUsed = [MSMobileCenter sharedInstance].sdkConfigured && self.started;
   if (!canBeUsed) {
-    MSLogError([MSMobileCenter getLoggerTag],
+    MSLogError([MSMobileCenter logTag],
                @"%@ service hasn't been started. You need to call "
                @"[MSMobileCenter start:YOUR_APP_SECRET withServices:LIST_OF_SERVICES] first.",
                MS_CLASS_NAME_WITHOUT_PREFIX);
@@ -84,7 +84,7 @@
   @synchronized([self sharedInstance]) {
     if ([[self sharedInstance] canBeUsed]) {
       if (![MSMobileCenter isEnabled] && ![MSMobileCenter sharedInstance].enabledStateUpdating) {
-        MSLogError([MSMobileCenter getLoggerTag], @"The SDK is disabled. Re-enable the whole SDK from MobileCenter "
+        MSLogError([MSMobileCenter logTag], @"The SDK is disabled. Re-enable the whole SDK from MobileCenter "
                                                   @"first before enabling %@ service.",
                    MS_CLASS_NAME_WITHOUT_PREFIX);
       } else {

--- a/MobileCenter/MobileCenter/Internals/MSServiceInternal.h
+++ b/MobileCenter/MobileCenter/Internals/MSServiceInternal.h
@@ -31,10 +31,10 @@
 + (instancetype)sharedInstance;
 
 /**
- * Get the logger tag for this service.
+ * Get the log tag for this service.
  *
  * @return A name of logger tag for this service.
  */
-+ (NSString *)getLoggerTag;
++ (NSString *)logTag;
 
 @end

--- a/MobileCenter/MobileCenter/Internals/Model/Utils/MSUserDefaults.m
+++ b/MobileCenter/MobileCenter/Internals/Model/Utils/MSUserDefaults.m
@@ -37,7 +37,7 @@ static NSString *const kMSUserDefaultsTs = @"_ts";
   /* Get from local store */
   NSDictionary *store = [[NSUserDefaults standardUserDefaults] dictionaryForKey:key];
   CFAbsoluteTime ts = [store[kMSUserDefaultsTs] floatValue];
-  MSLogVerbose([MSMobileCenter getLoggerTag], @"Settings:store[%@]=%@", key, store);
+  MSLogVerbose([MSMobileCenter logTag], @"Settings:store[%@]=%@", key, store);
 
   /* Force update if timestamp expiration is reached */
   if (ts <= 0.0 || expiration <= 0.0 || fabs(CFAbsoluteTimeGetCurrent() - ts) < expiration) {
@@ -50,7 +50,7 @@ static NSString *const kMSUserDefaultsTs = @"_ts";
 
   /* If still values to update */
   if ([update count] > 0) {
-    MSLogDebug([MSMobileCenter getLoggerTag], @"Settings:update[%@]=%@", key, update);
+    MSLogDebug([MSMobileCenter logTag], @"Settings:update[%@]=%@", key, update);
 
     /* Copy store as a mutable version */
     NSMutableDictionary *d = [store mutableCopy];

--- a/MobileCenter/MobileCenter/Internals/Sender/MSHttpSender.m
+++ b/MobileCenter/MobileCenter/Internals/Sender/MSHttpSender.m
@@ -73,7 +73,7 @@ static NSString *const kMSApiPath = @"/logs";
       NSDictionary *userInfo = @{NSLocalizedDescriptionKey : kMSMCLogInvalidContainerErrorDesc};
       NSError *error =
           [NSError errorWithDomain:kMSMCErrorDomain code:kMSMCLogInvalidContainerErrorCode userInfo:userInfo];
-      MSLogError([MSMobileCenter getLoggerTag], @"%@", [error localizedDescription]);
+      MSLogError([MSMobileCenter logTag], @"%@", [error localizedDescription]);
       handler(batchId, error, nil);
       return;
     }
@@ -143,7 +143,7 @@ static NSString *const kMSApiPath = @"/logs";
 - (void)suspend {
   @synchronized(self) {
     if (!self.suspended) {
-      MSLogInfo([MSMobileCenter getLoggerTag], @"Suspend sender.");
+      MSLogInfo([MSMobileCenter logTag], @"Suspend sender.");
       self.suspended = YES;
 
       // Suspend all tasks.
@@ -178,7 +178,7 @@ static NSString *const kMSApiPath = @"/logs";
 
     // Resume only while enabled.
     if (self.suspended && self.enabled) {
-      MSLogInfo([MSMobileCenter getLoggerTag], @"Resume sender.");
+      MSLogInfo([MSMobileCenter logTag], @"Resume sender.");
       self.suspended = NO;
 
       // Resume existing calls.
@@ -229,7 +229,7 @@ static NSString *const kMSApiPath = @"/logs";
                         completionHandler:^(NSData *data, NSURLResponse *response, NSError *error) {
                           @synchronized(self) {
                             NSInteger statusCode = [MSSenderUtil getStatusCode:response];
-                            MSLogDebug([MSMobileCenter getLoggerTag], @"HTTP response received with status code:%lu",
+                            MSLogDebug([MSMobileCenter logTag], @"HTTP response received with status code:%lu",
                                        (unsigned long)statusCode);
 
                             // Call handles the completion.
@@ -249,11 +249,11 @@ static NSString *const kMSApiPath = @"/logs";
 - (void)callCompletedWithId:(NSString *)callId {
   @synchronized(self) {
     if (!callId) {
-      MSLogWarning([MSMobileCenter getLoggerTag], @"Call object is invalid");
+      MSLogWarning([MSMobileCenter logTag], @"Call object is invalid");
       return;
     }
     [self.pendingCalls removeObjectForKey:callId];
-    MSLogInfo([MSMobileCenter getLoggerTag], @"Removed batch id:%@ from pending calls:%@", callId,
+    MSLogInfo([MSMobileCenter logTag], @"Removed batch id:%@ from pending calls:%@", callId,
               [self.pendingCalls description]);
   }
 }
@@ -284,8 +284,8 @@ static NSString *const kMSApiPath = @"/logs";
 
   // Don't loose time pretty printing headers if not going to be printed.
   if ([MSLogger currentLogLevel] <= MSLogLevelVerbose) {
-    MSLogVerbose([MSMobileCenter getLoggerTag], @"URL: %@", request.URL);
-    MSLogVerbose([MSMobileCenter getLoggerTag], @"Headers: %@", [self prettyPrintHeaders:request.allHTTPHeaderFields]);
+    MSLogVerbose([MSMobileCenter logTag], @"URL: %@", request.URL);
+    MSLogVerbose([MSMobileCenter logTag], @"Headers: %@", [self prettyPrintHeaders:request.allHTTPHeaderFields]);
   }
 
   return request;
@@ -295,10 +295,10 @@ static NSString *const kMSApiPath = @"/logs";
 
 - (void)networkStateChanged {
   if ([self.reachability currentReachabilityStatus] == NotReachable) {
-    MSLogInfo([MSMobileCenter getLoggerTag], @"Internet connection is down.");
+    MSLogInfo([MSMobileCenter logTag], @"Internet connection is down.");
     [self suspend];
   } else {
-    MSLogInfo([MSMobileCenter getLoggerTag], @"Internet connection is up.");
+    MSLogInfo([MSMobileCenter logTag], @"Internet connection is up.");
     [self resume];
   }
 }

--- a/MobileCenter/MobileCenter/Internals/Sender/MSRetriableCall.m
+++ b/MobileCenter/MobileCenter/Internals/Sender/MSRetriableCall.m
@@ -43,7 +43,7 @@
   // Create queue.
   self.timerSource = dispatch_source_create(DISPATCH_SOURCE_TYPE_TIMER, 0, 0, DISPATCH_TARGET_QUEUE_DEFAULT);
   int64_t delta = NSEC_PER_SEC * [self delayForRetryCount:self.retryCount];
-  MSLogDebug([MSMobileCenter getLoggerTag], @"Call attempt #%lu failed, it will be retried in %.f ms.",
+  MSLogDebug([MSMobileCenter logTag], @"Call attempt #%lu failed, it will be retried in %.f ms.",
              (unsigned long)self.retryCount, round(delta / 1000000));
   self.retryCount++;
   dispatch_source_set_timer(self.timerSource, dispatch_walltime(NULL, delta), 1ull * NSEC_PER_SEC, 1ull * NSEC_PER_SEC);
@@ -77,7 +77,7 @@
 
     // Reset the retry count, will retry once the connection is established again.
     [self resetRetry];
-    MSLogInfo([MSMobileCenter getLoggerTag], @"Internet connection is down.");
+    MSLogInfo([MSMobileCenter logTag], @"Internet connection is down.");
     [sender suspend];
   }
 

--- a/MobileCenter/MobileCenter/Internals/Storage/MSFileStorage.m
+++ b/MobileCenter/MobileCenter/Internals/Storage/MSFileStorage.m
@@ -189,7 +189,7 @@ static NSUInteger const MSDefaultLogCountLimit = 50;
       _baseDirectoryPath = [appSupportPath stringByAppendingPathComponent:kMSLogsDirectory];
     }
 
-    MSLogVerbose([MSMobileCenter getLoggerTag], @"Storage Path:\n%@", _baseDirectoryPath);
+    MSLogVerbose([MSMobileCenter logTag], @"Storage Path:\n%@", _baseDirectoryPath);
   }
 
   return _baseDirectoryPath;

--- a/MobileCenter/MobileCenter/Internals/Storage/MSFileUtil.m
+++ b/MobileCenter/MobileCenter/Internals/Storage/MSFileUtil.m
@@ -54,10 +54,10 @@
 
   NSError *error;
   if ([data writeToFile:file.filePath options:NSDataWritingAtomic error:&error]) {
-    MSLogVerbose([MSMobileCenter getLoggerTag], @"File %@: has been successfully written", file.filePath);
+    MSLogVerbose([MSMobileCenter logTag], @"File %@: has been successfully written", file.filePath);
     return YES;
   } else {
-    MSLogError([MSMobileCenter getLoggerTag], @"Error writing file %@: %@", file.filePath, error.localizedDescription);
+    MSLogError([MSMobileCenter logTag], @"Error writing file %@: %@", file.filePath, error.localizedDescription);
     return NO;
   }
 }
@@ -69,10 +69,10 @@
 
   NSError *error;
   if ([self.fileManager removeItemAtPath:file.filePath error:&error]) {
-    MSLogVerbose([MSMobileCenter getLoggerTag], @"File %@: has been successfully deleted", file.filePath);
+    MSLogVerbose([MSMobileCenter logTag], @"File %@: has been successfully deleted", file.filePath);
     return YES;
   } else {
-    MSLogError([MSMobileCenter getLoggerTag], @"Error deleting file %@: %@", file.filePath, error.localizedDescription);
+    MSLogError([MSMobileCenter logTag], @"Error deleting file %@: %@", file.filePath, error.localizedDescription);
     return NO;
   }
 }
@@ -85,9 +85,9 @@
   NSError *error;
   NSData *data = [NSData dataWithContentsOfFile:file.filePath options:nil error:&error];
   if (error) {
-    MSLogError([MSMobileCenter getLoggerTag], @"Error writing file %@: %@", file.filePath, error.localizedDescription);
+    MSLogError([MSMobileCenter logTag], @"Error writing file %@: %@", file.filePath, error.localizedDescription);
   } else {
-    MSLogVerbose([MSMobileCenter getLoggerTag], @"File %@: has been successfully written", file.filePath);
+    MSLogVerbose([MSMobileCenter logTag], @"File %@: has been successfully written", file.filePath);
   }
   return data;
 }
@@ -105,7 +105,7 @@
   NSError *error;
   NSArray *allFiles = [fileManager contentsOfDirectoryAtPath:directoryPath error:&error];
   if (error) {
-    MSLogError([MSMobileCenter getLoggerTag], @"Couldn't read %@-files for directory %@: %@", fileExtension, directoryPath,
+    MSLogError([MSMobileCenter logTag], @"Couldn't read %@-files for directory %@: %@", fileExtension, directoryPath,
                 error.localizedDescription);
     return nil;
   } else {
@@ -134,7 +134,7 @@
   if (!error) {
     creationDate = attributes[NSFileCreationDate];
   } else {
-    MSLogWarning([MSMobileCenter getLoggerTag], @"Couldn't read creation date of file %@: %@", filePath, error.localizedDescription);
+    MSLogWarning([MSMobileCenter logTag], @"Couldn't read creation date of file %@: %@", filePath, error.localizedDescription);
   }
 
   return creationDate;
@@ -150,7 +150,7 @@
       [self disableBackupForDirectoryPath:directoryPath];
       return YES;
     } else {
-      MSLogError([MSMobileCenter getLoggerTag], @"Couldn't create directory at path %@: %@", directoryPath, error.localizedDescription);
+      MSLogError([MSMobileCenter logTag], @"Couldn't create directory at path %@: %@", directoryPath, error.localizedDescription);
     }
   }
   return NO;
@@ -167,7 +167,7 @@
     if ([self.fileManager createFileAtPath:filePath contents:[NSData new] attributes:nil]) {
       return YES;
     } else {
-      MSLogError([MSMobileCenter getLoggerTag], @"Couldn't create new file at path %@", filePath);
+      MSLogError([MSMobileCenter logTag], @"Couldn't create new file at path %@", filePath);
     }
   }
   return NO;
@@ -177,7 +177,7 @@
   NSError *error = nil;
   NSURL *url = [NSURL fileURLWithPath:directoryPath];
   if (!url || ![url setResourceValue:@YES forKey:NSURLIsExcludedFromBackupKey error:&error]) {
-    MSLogError([MSMobileCenter getLoggerTag], @"Error excluding %@ from backup %@", directoryPath, error.localizedDescription);
+    MSLogError([MSMobileCenter logTag], @"Error excluding %@ from backup %@", directoryPath, error.localizedDescription);
     return NO;
   } else {
     return YES;

--- a/MobileCenter/MobileCenter/MSMobileCenter.m
+++ b/MobileCenter/MobileCenter/MSMobileCenter.m
@@ -126,7 +126,7 @@ static NSString *const kMSDefaultBaseUrl = @"https://in.mobile.azure.com";
   return debuggerIsAttached;
 }
 
-+ (NSString *)getLoggerTag {
++ (NSString *)logTag {
   return @"MobileCenter";
 }
 
@@ -144,12 +144,12 @@ static NSString *const kMSDefaultBaseUrl = @"https://in.mobile.azure.com";
 - (BOOL)configure:(NSString *)appSecret {
   BOOL success = false;
   if (self.sdkConfigured) {
-    MSLogAssert([MSMobileCenter getLoggerTag], @"Mobile Center SDK has already been configured.");
+    MSLogAssert([MSMobileCenter logTag], @"Mobile Center SDK has already been configured.");
   }
 
   // Validate and set the app secret.
   else if ([appSecret length] == 0) {
-    MSLogAssert([MSMobileCenter getLoggerTag], @"AppSecret is invalid.");
+    MSLogAssert([MSMobileCenter logTag], @"AppSecret is invalid.");
   }
 
   else {
@@ -175,7 +175,7 @@ static NSString *const kMSDefaultBaseUrl = @"https://in.mobile.azure.com";
     }
     success = true;
   }
-  MSLogAssert([MSMobileCenter getLoggerTag], @"Mobile Center SDK %@",
+  MSLogAssert([MSMobileCenter logTag], @"Mobile Center SDK %@",
               (success) ? @"configured successfully." : @"configuration failed.");
   return success;
 }
@@ -221,7 +221,7 @@ static NSString *const kMSDefaultBaseUrl = @"https://in.mobile.azure.com";
     [[service class] setEnabled:isEnabled];
   }
   self.enabledStateUpdating = NO;
-  MSLogInfo([MSMobileCenter getLoggerTag], @"Mobile Center SDK %@.", isEnabled ? @"enabled" : @"disabled");
+  MSLogInfo([MSMobileCenter logTag], @"Mobile Center SDK %@.", isEnabled ? @"enabled" : @"disabled");
 }
 
 - (BOOL)isEnabled {
@@ -314,7 +314,7 @@ static NSString *const kMSDefaultBaseUrl = @"https://in.mobile.azure.com";
 - (BOOL)canBeUsed {
   BOOL canBeUsed = self.sdkConfigured;
   if (!canBeUsed) {
-    MSLogError([MSMobileCenter getLoggerTag],
+    MSLogError([MSMobileCenter logTag],
                @"Mobile Center SDK hasn't been configured. You need to call [MSMobileCenter "
                @"start:YOUR_APP_SECRET withServices:LIST_OF_SERVICES] first.");
   }

--- a/MobileCenter/MobileCenterTests/MSHttpSenderTests.m
+++ b/MobileCenter/MobileCenterTests/MSHttpSenderTests.m
@@ -112,8 +112,7 @@ static NSString *const kMSAppSecret = @"mockAppSecret";
         XCTAssertEqual(error.domain, kMSMCErrorDomain);
         XCTAssertEqual(error.code, kMSMCConnectionHttpErrorCode);
         XCTAssertEqual(error.localizedDescription, kMSMCConnectionHttpErrorDesc);
-        XCTAssertEqual(error.userInfo[kMSMCConnectionHttpCodeErrorKey], @(MSHTTPCodesNo404NotFound));
-
+        XCTAssertTrue([error.userInfo[kMSMCConnectionHttpCodeErrorKey] isEqual:@(MSHTTPCodesNo404NotFound)]);
         [expectation fulfill];
       }];
 

--- a/MobileCenter/MobileCenterTests/MSServiceAbstractTest.m
+++ b/MobileCenter/MobileCenterTests/MSServiceAbstractTest.m
@@ -43,7 +43,7 @@
   return MSPriorityDefault;
 }
 
-+ (NSString *)getLoggerTag {
++ (NSString *)logTag {
   return @"MSServiceAbstractTest";
 }
 

--- a/MobileCenterAnalytics/MobileCenterAnalytics/Internals/Session/MSSessionTracker.m
+++ b/MobileCenterAnalytics/MobileCenterAnalytics/Internals/Session/MSSessionTracker.m
@@ -80,7 +80,7 @@ static NSUInteger const kMSMaxSessionHistoryCount = 5;
       // Persist the session history in NSData format.
       [MS_USER_DEFAULTS setObject:[NSKeyedArchiver archivedDataWithRootObject:self.pastSessions]
                            forKey:kMSPastSessionsKey];
-      MSLogInfo([MSAnalytics getLoggerTag], @"New session ID: %@", _sessionId);
+      MSLogInfo([MSAnalytics logTag], @"New session ID: %@", _sessionId);
 
       // Create a start session log.
       MSStartSessionLog *log = [[MSStartSessionLog alloc] init];

--- a/MobileCenterAnalytics/MobileCenterAnalytics/MSAnalytics.m
+++ b/MobileCenterAnalytics/MobileCenterAnalytics/MSAnalytics.m
@@ -59,10 +59,10 @@ static dispatch_once_t onceToken;
 
   // Set up swizzling for auto page tracking.
   [MSAnalyticsCategory activateCategory];
-  MSLogVerbose([MSAnalytics getLoggerTag], @"Started analytics service.");
+  MSLogVerbose([MSAnalytics logTag], @"Started analytics service.");
 }
 
-+ (NSString *)getLoggerTag {
++ (NSString *)logTag {
   return @"MobileCenterAnalytics";
 }
 
@@ -100,13 +100,13 @@ static dispatch_once_t onceToken;
       });
     }
 
-    MSLogInfo([MSAnalytics getLoggerTag], @"Analytics service has been enabled.");
+    MSLogInfo([MSAnalytics logTag], @"Analytics service has been enabled.");
   } else {
     [self.logManager removeDelegate:self.sessionTracker];
     [self.logManager removeChannelDelegate:self forPriority:self.priority];
     [self.sessionTracker stop];
     [self.sessionTracker clearSessions];
-    MSLogInfo([MSAnalytics getLoggerTag], @"Analytics service has been disabled.");
+    MSLogInfo([MSAnalytics logTag], @"Analytics service has been disabled.");
   }
 }
 
@@ -171,7 +171,7 @@ static dispatch_once_t onceToken;
 
     // Check if property dictionary contains non-string values.
     if (![self validateProperties:properties]) {
-      MSLogError([MSAnalytics getLoggerTag], @"The event contains unsupported value type(s). Values should be NSString type.");
+      MSLogError([MSAnalytics logTag], @"The event contains unsupported value type(s). Values should be NSString type.");
       return;
     }
     log.properties = properties;
@@ -192,7 +192,7 @@ static dispatch_once_t onceToken;
 
     // Check if property dictionary contains non-string values.
     if (![self validateProperties:properties]) {
-      MSLogError([MSAnalytics getLoggerTag], @"The page contains unsupported value type(s). Values should be NSString type.");
+      MSLogError([MSAnalytics logTag], @"The page contains unsupported value type(s). Values should be NSString type.");
       return;
     }
     log.properties = properties;

--- a/MobileCenterCrashes/MobileCenterCrashes/Internals/MSWrapperExceptionManager.m
+++ b/MobileCenterCrashes/MobileCenterCrashes/Internals/MSWrapperExceptionManager.m
@@ -87,7 +87,7 @@
                                  attributes:nil
                                       error:&error];
       if (error) {
-        MSLogError([MSCrashes getLoggerTag], @"Failed to create directory %@: %@",
+        MSLogError([MSCrashes logTag], @"Failed to create directory %@: %@",
                    [[self class] directoryPath], error.localizedDescription);
       }
     }
@@ -120,7 +120,7 @@
   MSException *loadedException = [NSKeyedUnarchiver unarchiveObjectWithFile:filename];
 
   if (!loadedException) {
-    MSLogError([MSCrashes getLoggerTag], @"Could not load wrapper exception from file %@", filename);
+    MSLogError([MSCrashes logTag], @"Could not load wrapper exception from file %@", filename);
     return nil;
   }
 
@@ -135,7 +135,7 @@
   [self saveWrapperExceptionData:uuidRef];
   BOOL success = [NSKeyedArchiver archiveRootObject:_wrapperException toFile:filename];
   if (!success) {
-    MSLogError([MSCrashes getLoggerTag], @"Failed to save file %@", filename);
+    MSLogError([MSCrashes logTag], @"Failed to save file %@", filename);
   }
 }
 
@@ -180,7 +180,7 @@
   NSError *error = nil;
   data = [NSData dataWithContentsOfFile:dataFilename options:NSDataReadingMappedIfSafe error:&error];
   if (error) {
-    MSLogError([MSCrashes getLoggerTag], @"Error loading file %@: %@",
+    MSLogError([MSCrashes logTag], @"Error loading file %@: %@",
                dataFilename, error.localizedDescription);
   }
   return data;
@@ -212,7 +212,7 @@
   NSError *error = nil;
   [[NSFileManager defaultManager] removeItemAtPath:path error:&error];
   if (error) {
-    MSLogError([MSCrashes getLoggerTag], @"Error deleting file %@: %@",
+    MSLogError([MSCrashes logTag], @"Error deleting file %@: %@",
                path, error.localizedDescription);
   }
 }

--- a/MobileCenterCrashes/MobileCenterCrashes/Internals/Utils/MSErrorLogFormatter.m
+++ b/MobileCenterCrashes/MobileCenterCrashes/Internals/Utils/MSErrorLogFormatter.m
@@ -638,7 +638,7 @@ static const char *findSEL(const char *imageName, NSString *imageUUID, uint64_t 
                                                               range:NSMakeRange(0, [path length])
                                                        withTemplate:@"/Users/USER/"];
     if (error) {
-      MSLogError([MSCrashes getLoggerTag], @"String replacing failed - %@", error.localizedDescription);
+      MSLogError([MSCrashes logTag], @"String replacing failed - %@", error.localizedDescription);
     }
   } else if (([path length] > 0) && (![path containsString:@"Users"])) {
     return path;

--- a/MobileCenterCrashes/MobileCenterCrashes/MSCrashes.m
+++ b/MobileCenterCrashes/MobileCenterCrashes/MSCrashes.m
@@ -64,14 +64,14 @@ static void uncaught_cxx_exception_handler(const MSCrashesUncaughtCXXExceptionIn
     if ([[self sharedInstance] canBeUsed]) {
       if ([MSUtil currentAppEnvironment] != MSEnvironmentAppStore) {
         if ([MSMobileCenter isDebuggerAttached]) {
-          MSLogWarning([MSCrashes getLoggerTag],
+          MSLogWarning([MSCrashes logTag],
                   @"The debugger is attached. The following crash cannot be detected by the SDK!");
         }
 
         __builtin_trap();
       }
     } else {
-      MSLogWarning([MSCrashes getLoggerTag],
+      MSLogWarning([MSCrashes logTag],
               @"GenerateTestCrash was just called in an App Store environment. The call will "
                       @"be ignored");
     }
@@ -117,7 +117,7 @@ static void uncaught_cxx_exception_handler(const MSCrashesUncaughtCXXExceptionIn
     if ([crashes delegateImplementsAttachmentCallback])
       [log setErrorAttachment:[crashes.delegate attachmentWithCrashes:crashes forErrorReport:report]];
     else
-      MSLogDebug([MSCrashes getLoggerTag], @"attachmentWithCrashes is not implemented");
+      MSLogDebug([MSCrashes logTag], @"attachmentWithCrashes is not implemented");
 
     // Send log to log manager.
     [crashes.logManager processLog:log withPriority:crashes.priority];
@@ -187,26 +187,26 @@ static void uncaught_cxx_exception_handler(const MSCrashesUncaughtCXXExceptionIn
     if (self.crashFiles.count > 0) {
       [self startDelayedCrashProcessing];
     }
-    MSLogInfo([MSCrashes getLoggerTag], @"Crashes service has been enabled.");
+    MSLogInfo([MSCrashes logTag], @"Crashes service has been enabled.");
 
     // More details on log if a debugger is attached.
     if ([MSMobileCenter isDebuggerAttached]) {
-      MSLogInfo([MSCrashes getLoggerTag], @"Crashes service has been enabled but the service cannot detect crashes due to running the application with a debugger attached.");
+      MSLogInfo([MSCrashes logTag], @"Crashes service has been enabled but the service cannot detect crashes due to running the application with a debugger attached.");
     }
     else {
-      MSLogInfo([MSCrashes getLoggerTag], @"Crashes service has been enabled.");
+      MSLogInfo([MSCrashes logTag], @"Crashes service has been enabled.");
     }
   } else {
 
     // Don't set PLCrashReporter to nil!
-    MSLogDebug([MSCrashes getLoggerTag], @"Cleaning up all crash files.");
+    MSLogDebug([MSCrashes logTag], @"Cleaning up all crash files.");
     [MSWrapperExceptionManager deleteAllWrapperExceptions];
     [MSWrapperExceptionManager deleteAllWrapperExceptionData];
     [self deleteAllFromCrashesDirectory];
     [self removeAnalyzerFile];
     [self.plCrashReporter purgePendingCrashReport];
     [self.logManager removeChannelDelegate:self forPriority:MSPriorityHigh];
-    MSLogInfo([MSCrashes getLoggerTag], @"Crashes service has been disabled.");
+    MSLogInfo([MSCrashes logTag], @"Crashes service has been disabled.");
   }
 }
 
@@ -223,10 +223,10 @@ static void uncaught_cxx_exception_handler(const MSCrashesUncaughtCXXExceptionIn
 
 - (void)startWithLogManager:(id <MSLogManager>)logManager {
   [super startWithLogManager:logManager];
-  MSLogVerbose([MSCrashes getLoggerTag], @"Started crash service.");
+  MSLogVerbose([MSCrashes logTag], @"Started crash service.");
 }
 
-+ (NSString *)getLoggerTag {
++ (NSString *)logTag {
   return @"MobileCenterCrashes";
 }
 
@@ -271,7 +271,7 @@ static void uncaught_cxx_exception_handler(const MSCrashesUncaughtCXXExceptionIn
 
 - (void)configureCrashReporter {
   if (_plCrashReporter) {
-    MSLogDebug([MSCrashes getLoggerTag], @"Already configured PLCrashReporter.");
+    MSLogDebug([MSCrashes logTag], @"Already configured PLCrashReporter.");
     return;
   }
 
@@ -288,7 +288,7 @@ static void uncaught_cxx_exception_handler(const MSCrashesUncaughtCXXExceptionIn
    handler type is set.
    */
   if ([MSMobileCenter isDebuggerAttached]) {
-    MSLogWarning([MSCrashes getLoggerTag],
+    MSLogWarning([MSCrashes logTag],
             @"Detecting crashes is NOT enabled due to running the app with a debugger attached.");
   } else {
 
@@ -309,14 +309,14 @@ static void uncaught_cxx_exception_handler(const MSCrashesUncaughtCXXExceptionIn
     NSError *error = NULL;
     [self.plCrashReporter setCrashCallbacks:&plCrashCallbacks];
     if (![self.plCrashReporter enableCrashReporterAndReturnError:&error])
-      MSLogError([MSCrashes getLoggerTag], @"Could not enable crash reporter: %@", [error localizedDescription]);
+      MSLogError([MSCrashes logTag], @"Could not enable crash reporter: %@", [error localizedDescription]);
     NSUncaughtExceptionHandler *currentHandler = NSGetUncaughtExceptionHandler();
     if (currentHandler && currentHandler != initialHandler) {
       self.exceptionHandler = currentHandler;
 
-      MSLogDebug([MSCrashes getLoggerTag], @"Exception handler successfully initialized.");
+      MSLogDebug([MSCrashes logTag], @"Exception handler successfully initialized.");
     } else {
-      MSLogError([MSCrashes getLoggerTag],
+      MSLogError([MSCrashes logTag],
               @"Exception handler could not be set. Make sure there is no other exception handler set up!");
     }
     [MSCrashesUncaughtCXXExceptionHandlerManager addCXXExceptionHandler:uncaught_cxx_exception_handler];
@@ -338,7 +338,7 @@ static void uncaught_cxx_exception_handler(const MSCrashesUncaughtCXXExceptionIn
     return;
   }
 
-  MSLogDebug([MSCrashes getLoggerTag], @"Start delayed CrashManager processing");
+  MSLogDebug([MSCrashes logTag], @"Start delayed CrashManager processing");
 
   // Was our own exception handler successfully added?
   if (self.exceptionHandler) {
@@ -352,7 +352,7 @@ static void uncaught_cxx_exception_handler(const MSCrashesUncaughtCXXExceptionIn
      * log message for details.
      */
     if (self.exceptionHandler != currentHandler) {
-      MSLogWarning([MSCrashes getLoggerTag], @"Another exception handler was added. If "
+      MSLogWarning([MSCrashes logTag], @"Another exception handler was added. If "
               @"this invokes any kind of exit() after processing the "
               @"exception, which causes any subsequent error handler "
               @"not to be invoked, these crashes will NOT be reported "
@@ -379,14 +379,14 @@ static void uncaught_cxx_exception_handler(const MSCrashesUncaughtCXXExceptionIn
     // we start sending always with the oldest pending one
     NSData *crashFileData = [NSData dataWithContentsOfFile:filePath];
     if ([crashFileData length] > 0) {
-      MSLogVerbose([MSCrashes getLoggerTag], @"Crash report found");
+      MSLogVerbose([MSCrashes logTag], @"Crash report found");
       if (self.isEnabled) {
         MSPLCrashReport *report = [[MSPLCrashReport alloc] initWithData:crashFileData error:&error];
         MSAppleErrorLog *log = [MSErrorLogFormatter errorLogFromCrashReport:report];
         MSErrorReport *errorReport = [MSErrorLogFormatter errorReportFromLog:(log)];
         uuidString = errorReport.incidentIdentifier;
         if ([self shouldProcessErrorReport:errorReport]) {
-          MSLogDebug([MSCrashes getLoggerTag],
+          MSLogDebug([MSCrashes logTag],
                   @"shouldProcessErrorReport is not implemented or returned YES, processing the crash report: %@",
                   report.debugDescription);
 
@@ -397,11 +397,11 @@ static void uncaught_cxx_exception_handler(const MSCrashesUncaughtCXXExceptionIn
 
           continue;
         } else {
-          MSLogDebug([MSCrashes getLoggerTag], @"shouldProcessErrorReport returned NO, discard the crash report: %@",
+          MSLogDebug([MSCrashes logTag], @"shouldProcessErrorReport returned NO, discard the crash report: %@",
                   report.debugDescription);
         }
       } else {
-        MSLogDebug([MSCrashes getLoggerTag], @"Crashes service is disabled, discard the crash report");
+        MSLogDebug([MSCrashes logTag], @"Crashes service is disabled, discard the crash report");
       }
 
       [MSWrapperExceptionManager deleteWrapperExceptionDataWithUUIDString:uuidString];
@@ -416,14 +416,14 @@ static void uncaught_cxx_exception_handler(const MSCrashesUncaughtCXXExceptionIn
     if (flag && [flag boolValue]) {
 
       // User confirmation is set to MSUserConfirmationAlways.
-      MSLogDebug([MSCrashes getLoggerTag],
+      MSLogDebug([MSCrashes logTag],
               @"The flag for user confirmation is set to MSUserConfirmationAlways, continue sending logs");
       [MSCrashes notifyWithUserConfirmation:MSUserConfirmationSend];
       return;
     } else if (!_userConfirmationHandler || !_userConfirmationHandler(_unprocessedReports)) {
 
       // User confirmation handler doesn't exist or returned NO which means 'want to process'.
-      MSLogDebug([MSCrashes getLoggerTag],
+      MSLogDebug([MSCrashes logTag],
               @"The user confirmation handler is not implemented or returned NO, continue sending logs");
       [MSCrashes notifyWithUserConfirmation:MSUserConfirmationSend];
     }
@@ -439,7 +439,7 @@ static void uncaught_cxx_exception_handler(const MSCrashesUncaughtCXXExceptionIn
     [_fileManager removeItemAtPath:path error:&error];
 
     if (error) {
-      MSLogError([MSCrashes getLoggerTag], @"Error deleting file %@: %@", filePath, error.localizedDescription);
+      MSLogError([MSCrashes logTag], @"Error deleting file %@: %@", filePath, error.localizedDescription);
     }
   }
   [self.crashFiles removeAllObjects];
@@ -466,7 +466,7 @@ static void uncaught_cxx_exception_handler(const MSCrashesUncaughtCXXExceptionIn
     NSString *cacheFilename = [NSString stringWithFormat:@"%.0f", [NSDate timeIntervalSinceReferenceDate]];
 
     if (crashData == nil) {
-      MSLogError([MSCrashes getLoggerTag], @"Could not load crash report: %@", error);
+      MSLogError([MSCrashes logTag], @"Could not load crash report: %@", error);
     } else {
 
       // Get data of PLCrashReport and write it to SDK directory
@@ -476,7 +476,7 @@ static void uncaught_cxx_exception_handler(const MSCrashesUncaughtCXXExceptionIn
         [crashData writeToFile:[self.crashesDir stringByAppendingPathComponent:cacheFilename] atomically:YES];
         _lastSessionCrashReport = [MSErrorLogFormatter errorReportFromCrashReport:report];
       } else {
-        MSLogWarning([MSCrashes getLoggerTag], @"Could not parse crash report");
+        MSLogWarning([MSCrashes logTag], @"Could not parse crash report");
       }
     }
 
@@ -512,7 +512,7 @@ static void uncaught_cxx_exception_handler(const MSCrashesUncaughtCXXExceptionIn
   if ([self.fileManager fileExistsAtPath:self.analyzerInProgressFile]) {
     NSError *error = nil;
     if (![self.fileManager removeItemAtPath:self.analyzerInProgressFile error:&error]) {
-      MSLogError([MSCrashes getLoggerTag], @"Couldn't remove analyzer file at %@: ", self.analyzerInProgressFile);
+      MSLogError([MSCrashes logTag], @"Couldn't remove analyzer file at %@: ", self.analyzerInProgressFile);
     }
   }
 }
@@ -546,7 +546,7 @@ static void uncaught_cxx_exception_handler(const MSCrashesUncaughtCXXExceptionIn
   // This shouldn't happen because the callback should only happen once plCrashReporter
   // has written the report to disk
   if (!crashData) {
-    MSLogError([MSCrashes getLoggerTag], @"Could not load crash data: %@", error.localizedDescription);
+    MSLogError([MSCrashes logTag], @"Could not load crash data: %@", error.localizedDescription);
   }
 
   MSPLCrashReport *report = [[MSPLCrashReport alloc] initWithData:crashData error:&error];
@@ -554,7 +554,7 @@ static void uncaught_cxx_exception_handler(const MSCrashesUncaughtCXXExceptionIn
   if (report) {
     [MSWrapperExceptionManager saveWrapperException:report.uuidRef];
   } else {
-    MSLogError([MSCrashes getLoggerTag], @"Could not load crash report: %@", error.localizedDescription);
+    MSLogError([MSCrashes logTag], @"Could not load crash report: %@", error.localizedDescription);
   }
 }
 


### PR DESCRIPTION
The methodsignature `getLoggerTag` feels weird as "getters" in objective-c usually omit the `get`.
This PR renames the method. It includes #247 to make sure tests pass.