### PR TITLE
Fix warnings related to direct access of ivars

### DIFF
--- a/MobileCenter/MobileCenter/Internals/Channel/MSChannelDefault.m
+++ b/MobileCenter/MobileCenter/Internals/Channel/MSChannelDefault.m
@@ -258,7 +258,7 @@
 
     // Flush the queue as needed.
     if (strongSelf) {
-      if (strongSelf->_itemsCount > 0) {
+      if (strongSelf.itemsCount > 0) {
         [strongSelf flushQueue];
       }
       [strongSelf resetTimer];

--- a/MobileCenter/MobileCenter/Internals/Channel/MSChannelDefault.m
+++ b/MobileCenter/MobileCenter/Internals/Channel/MSChannelDefault.m
@@ -112,7 +112,7 @@
     // Save the log first.
     MSLogDebug([MSMobileCenter logTag], @"Saving log, type: %@.", item.type);
     BOOL success = [self.storage saveLog:item withStorageKey:self.configuration.name];
-    _itemsCount += 1;
+    self.itemsCount += 1;
     if (completion) {
       completion(success);
     }

--- a/MobileCenter/MobileCenter/Internals/Device/MSDeviceTracker.m
+++ b/MobileCenter/MobileCenter/Internals/Device/MSDeviceTracker.m
@@ -25,6 +25,13 @@ ms_info_t mobilecenter_library_info __attribute__((section("__TEXT,__ms_ios,regu
     .ms_build = MOBILE_CENTER_C_BUILD
 };
 
+@interface MSDeviceTracker()
+
+//we need set device inside class without warnings
+@property(nonatomic) MSDevice *device;
+
+@end
+
 @implementation MSDeviceTracker : NSObject
 
 @synthesize device = _device;
@@ -83,7 +90,7 @@ static BOOL needRefresh = YES;
     [self refreshWrapperSdk:newDevice];
 
     // Set the new device info.
-    _device = newDevice;
+    self.device = newDevice;
     needRefresh = NO;
   }
 }

--- a/MobileCenter/MobileCenter/Internals/Device/MSDeviceTracker.m
+++ b/MobileCenter/MobileCenter/Internals/Device/MSDeviceTracker.m
@@ -27,7 +27,7 @@ ms_info_t mobilecenter_library_info __attribute__((section("__TEXT,__ms_ios,regu
 
 @interface MSDeviceTracker()
 
-//we need set device inside class without warnings
+// We need a private setter for the device to avoid ivars direct access warning.
 @property(nonatomic) MSDevice *device;
 
 @end

--- a/MobileCenter/MobileCenter/Internals/MSServiceAbstract.m
+++ b/MobileCenter/MobileCenter/Internals/MSServiceAbstract.m
@@ -29,7 +29,7 @@
 
   // Get isEnabled value from persistence.
   // No need to cache the value in a property, user settings already have their cache mechanism.
-  NSNumber *isEnabledNumber = [_storage objectForKey:_isEnabledKey];
+  NSNumber *isEnabledNumber = [self.storage objectForKey:self.isEnabledKey];
 
   // Return the persisted value otherwise it's enabled by default.
   return (isEnabledNumber) ? [isEnabledNumber boolValue] : YES;

--- a/MobileCenter/MobileCenter/Internals/Sender/MSHttpSender.m
+++ b/MobileCenter/MobileCenter/Internals/Sender/MSHttpSender.m
@@ -286,7 +286,7 @@ static NSTimeInterval kRequestTimeout = 60.0;
     // Check if call has already been created(retry scenario).
     MSSenderCall *call = self.pendingCalls[callId];
     if (call == nil) {
-      call = [[MSSenderCall alloc] initWithRetryIntervals:_callsRetryIntervals];
+      call = [[MSSenderCall alloc] initWithRetryIntervals:self.callsRetryIntervals];
       call.delegate = self;
       call.data = data;
       call.callId = callId;

--- a/MobileCenter/MobileCenter/Internals/Sender/MSSenderCall.m
+++ b/MobileCenter/MobileCenter/Internals/Sender/MSSenderCall.m
@@ -68,7 +68,7 @@
 }
 
 - (void)resetRetry {
-  _retryCount = 0;
+  self.retryCount = 0;
   [self resetTimer];
 }
 

--- a/MobileCenter/MobileCenter/Internals/Storage/MSStorageBucket.m
+++ b/MobileCenter/MobileCenter/Internals/Storage/MSStorageBucket.m
@@ -28,7 +28,7 @@
       [self.availableFiles sortedArrayUsingComparator:^NSComparisonResult(MSFile *b1, MSFile *b2) {
         return [b1.creationDate compare:b2.creationDate];
       }];
-  _availableFiles = [sortedBatches mutableCopy];
+  self.availableFiles = [sortedBatches mutableCopy];
 }
 
 - (void)removeFile:(MSFile *)file {
@@ -44,12 +44,12 @@
   NSMutableArray *allFiles = [NSMutableArray new];
 
   // Transfer all available files
-  [allFiles addObjectsFromArray:_availableFiles];
-  [_availableFiles removeAllObjects];
+  [allFiles addObjectsFromArray:self.availableFiles];
+  [self.availableFiles removeAllObjects];
 
   // Transfer all blocked files
-  [allFiles addObjectsFromArray:_blockedFiles];
-  [_blockedFiles removeAllObjects];
+  [allFiles addObjectsFromArray:self.blockedFiles];
+  [self.blockedFiles removeAllObjects];
   return [allFiles copy];
 }
 

--- a/MobileCenter/MobileCenter/Internals/Vendor/Reachability/MS_Reachability.m
+++ b/MobileCenter/MobileCenter/Internals/Vendor/Reachability/MS_Reachability.m
@@ -51,10 +51,17 @@ static void ReachabilityCallback(SCNetworkReachabilityRef target, SCNetworkReach
   [[NSNotificationCenter defaultCenter] postNotificationName:kMSReachabilityChangedNotification object:noteObject];
 }
 
+#pragma mark - Reachability extension
+
+@interface MS_Reachability()
+
+@property (nonatomic) SCNetworkReachabilityRef reachabilityRef;
+
+@end
+
 #pragma mark - Reachability implementation
 
 @implementation MS_Reachability {
-  SCNetworkReachabilityRef _reachabilityRef;
 }
 
 + (instancetype)reachabilityWithHostName:(NSString *)hostName {
@@ -63,7 +70,7 @@ static void ReachabilityCallback(SCNetworkReachabilityRef target, SCNetworkReach
   if (reachability != NULL) {
     returnValue = [[self alloc] init];
     if (returnValue != NULL) {
-      returnValue->_reachabilityRef = reachability;
+      returnValue.reachabilityRef = reachability;
     } else {
       CFRelease(reachability);
     }
@@ -79,7 +86,7 @@ static void ReachabilityCallback(SCNetworkReachabilityRef target, SCNetworkReach
   if (reachability != NULL) {
     returnValue = [[self alloc] init];
     if (returnValue != NULL) {
-      returnValue->_reachabilityRef = reachability;
+      returnValue.reachabilityRef = reachability;
     } else {
       CFRelease(reachability);
     }
@@ -106,8 +113,8 @@ static void ReachabilityCallback(SCNetworkReachabilityRef target, SCNetworkReach
   BOOL returnValue = NO;
   SCNetworkReachabilityContext context = {0, (__bridge void *)(self), NULL, NULL, NULL};
 
-  if (SCNetworkReachabilitySetCallback(_reachabilityRef, ReachabilityCallback, &context)) {
-    if (SCNetworkReachabilityScheduleWithRunLoop(_reachabilityRef, CFRunLoopGetCurrent(), kCFRunLoopDefaultMode)) {
+  if (SCNetworkReachabilitySetCallback(self.reachabilityRef, ReachabilityCallback, &context)) {
+    if (SCNetworkReachabilityScheduleWithRunLoop(self.reachabilityRef, CFRunLoopGetCurrent(), kCFRunLoopDefaultMode)) {
       returnValue = YES;
     }
   }
@@ -116,15 +123,15 @@ static void ReachabilityCallback(SCNetworkReachabilityRef target, SCNetworkReach
 }
 
 - (void)stopNotifier {
-  if (_reachabilityRef != NULL) {
-    SCNetworkReachabilityUnscheduleFromRunLoop(_reachabilityRef, CFRunLoopGetCurrent(), kCFRunLoopDefaultMode);
+  if (self.reachabilityRef != NULL) {
+    SCNetworkReachabilityUnscheduleFromRunLoop(self.reachabilityRef, CFRunLoopGetCurrent(), kCFRunLoopDefaultMode);
   }
 }
 
 - (void)dealloc {
   [self stopNotifier];
-  if (_reachabilityRef != NULL) {
-    CFRelease(_reachabilityRef);
+  if (self.reachabilityRef != NULL) {
+    CFRelease(self.reachabilityRef);
   }
 }
 
@@ -172,10 +179,10 @@ If the target host is reachable and no connection is required then we'll assume 
 }
 
 - (BOOL)connectionRequired {
-  NSAssert(_reachabilityRef != NULL, @"connectionRequired called with NULL reachabilityRef");
+  NSAssert(self.reachabilityRef != NULL, @"connectionRequired called with NULL reachabilityRef");
   SCNetworkReachabilityFlags flags;
 
-  if (SCNetworkReachabilityGetFlags(_reachabilityRef, &flags)) {
+  if (SCNetworkReachabilityGetFlags(self.reachabilityRef, &flags)) {
     return (flags & kSCNetworkReachabilityFlagsConnectionRequired);
   }
 
@@ -183,11 +190,11 @@ If the target host is reachable and no connection is required then we'll assume 
 }
 
 - (NetworkStatus)currentReachabilityStatus {
-  NSAssert(_reachabilityRef != NULL, @"currentNetworkStatus called with NULL SCNetworkReachabilityRef");
+  NSAssert(self.reachabilityRef != NULL, @"currentNetworkStatus called with NULL SCNetworkReachabilityRef");
   NetworkStatus returnValue = NotReachable;
   SCNetworkReachabilityFlags flags;
 
-  if (SCNetworkReachabilityGetFlags(_reachabilityRef, &flags)) {
+  if (SCNetworkReachabilityGetFlags(self.reachabilityRef, &flags)) {
     returnValue = [self networkStatusForFlags:flags];
   }
 

--- a/MobileCenter/MobileCenter/MSMobileCenter.m
+++ b/MobileCenter/MobileCenter/MSMobileCenter.m
@@ -159,7 +159,7 @@ static NSString *const kMSDefaultBaseUrl = @"https://in.mobile.azure.com";
       [self applyPipelineEnabledState:self.isEnabled];
     }
 
-    _sdkConfigured = YES;
+    self.sdkConfigured = YES;
 
     // If the loglevel hasn't been customized before and we are not running in an app store environment, we set the
     // default loglevel to MSLogLevelWarning.
@@ -276,7 +276,7 @@ static NSString *const kMSDefaultBaseUrl = @"https://in.mobile.azure.com";
 - (void)initializeLogManager {
 
   // Construct log manager.
-  _logManager =
+  self.logManager =
       [[MSLogManagerDefault alloc] initWithAppSecret:self.appSecret installId:self.installId serverUrl:self.serverUrl];
 }
 

--- a/MobileCenterAnalytics/MobileCenterAnalytics/Internals/Session/MSSessionTracker.m
+++ b/MobileCenterAnalytics/MobileCenterAnalytics/Internals/Session/MSSessionTracker.m
@@ -199,7 +199,7 @@ static NSUInteger const kMSMaxSessionHistoryCount = 5;
   }
 
   // Update last created log time stamp.
-  _lastCreatedLogTime = [NSDate date];
+  self.lastCreatedLogTime = [NSDate date];
 }
 
 @end

--- a/MobileCenterAnalytics/MobileCenterAnalytics/MSAnalytics.m
+++ b/MobileCenterAnalytics/MobileCenterAnalytics/MSAnalytics.m
@@ -209,7 +209,7 @@ static dispatch_once_t onceToken;
 }
 
 - (BOOL)isAutoPageTrackingEnabled {
-  return _autoPageTrackingEnabled;
+  return self.autoPageTrackingEnabled;
 }
 
 - (void)sendLog:(id<MSLog>)log withPriority:(MSPriority)priority {

--- a/MobileCenterCrashes/MobileCenterCrashes/Internals/MSCrashesCXXExceptionWrapperException.m
+++ b/MobileCenterCrashes/MobileCenterCrashes/Internals/MSCrashesCXXExceptionWrapperException.m
@@ -4,9 +4,13 @@
 
 #import "MSCrashesCXXExceptionWrapperException.h"
 
-@implementation MSCrashesCXXExceptionWrapperException {
-  const MSCrashesUncaughtCXXExceptionInfo *_info;
-}
+@interface MSCrashesCXXExceptionWrapperException()
+
+@property (readonly,nonatomic) const MSCrashesUncaughtCXXExceptionInfo *info;
+
+@end
+
+@implementation MSCrashesCXXExceptionWrapperException
 
 - (instancetype)initWithCXXExceptionInfo:(const MSCrashesUncaughtCXXExceptionInfo *)info {
   extern char *__cxa_demangle(const char *mangled_name, char *output_buffer, size_t *length, int *status);
@@ -25,10 +29,11 @@
  * "sneaky" things that require knowledge of how PLCrashReporter works internally.
  */
 - (NSArray *)callStackReturnAddresses {
-  NSMutableArray *cxxFrames = [NSMutableArray arrayWithCapacity:_info->exception_frames_count];
+
+  NSMutableArray *cxxFrames = [NSMutableArray arrayWithCapacity:self.info->exception_frames_count];
   
-  for (uint32_t i = 0; i < _info->exception_frames_count; ++i) {
-    [cxxFrames addObject:[NSNumber numberWithUnsignedLongLong:_info->exception_frames[i]]];
+  for (uint32_t i = 0; i < self.info->exception_frames_count; ++i) {
+    [cxxFrames addObject:[NSNumber numberWithUnsignedLongLong:self.info->exception_frames[i]]];
   }
   
   return cxxFrames;

--- a/MobileCenterCrashes/MobileCenterCrashes/Internals/MSCrashesPrivate.h
+++ b/MobileCenterCrashes/MobileCenterCrashes/Internals/MSCrashesPrivate.h
@@ -24,8 +24,8 @@ struct MSCrashesBufferedLog {
   MSCrashesBufferedLog() = default;
 
   MSCrashesBufferedLog(NSString *path, NSData *data)
-      : bufferPath(path.UTF8String), buffer(&reinterpret_cast<const char *>(data.bytes)[0],
-                                            &reinterpret_cast<const char *>(data.bytes)[data.length]) {}
+  : bufferPath(path.UTF8String), buffer(&reinterpret_cast<const char *>(data.bytes)[0],
+                                        &reinterpret_cast<const char *>(data.bytes)[data.length]) {}
 };
 
 /**
@@ -122,6 +122,26 @@ typedef struct MSCrashesCallbacks {
  * A flag that indicates that crashes are currently sent to the backend.
  */
 @property(nonatomic) BOOL sendingInProgress;
+
+/**
+ * Indicates if the app crashed in the previous session
+ *
+ * Use this on startup, to check if the app starts the first time after it
+ crashed
+ * previously. You can use this also to disable specific events, like asking
+ * the user to rate your app.
+
+ * @warning This property only has a correct value, once the sdk has been
+ properly initialized!
+
+ * @see lastSessionCrashReport
+ */
+@property(atomic, readonly) BOOL didCrashInLastSession;
+
+/**
+ * Detail information about the last crash.
+ */
+@property(atomic, readonly, getter=getLastSessionCrashReport) MSErrorReport *lastSessionCrashReport;
 
 /**
  * Temporary storage for crashes logs to handle user confirmation and callbacks.

--- a/MobileCenterCrashes/MobileCenterCrashes/Internals/MSCrashesPrivate.h
+++ b/MobileCenterCrashes/MobileCenterCrashes/Internals/MSCrashesPrivate.h
@@ -124,26 +124,6 @@ typedef struct MSCrashesCallbacks {
 @property(nonatomic) BOOL sendingInProgress;
 
 /**
- * Indicates if the app crashed in the previous session
- *
- * Use this on startup, to check if the app starts the first time after it
- crashed
- * previously. You can use this also to disable specific events, like asking
- * the user to rate your app.
-
- * @warning This property only has a correct value, once the sdk has been
- properly initialized!
-
- * @see lastSessionCrashReport
- */
-@property(atomic, readonly) BOOL didCrashInLastSession;
-
-/**
- * Detail information about the last crash.
- */
-@property(atomic, readonly, getter=getLastSessionCrashReport) MSErrorReport *lastSessionCrashReport;
-
-/**
  * Temporary storage for crashes logs to handle user confirmation and callbacks.
  */
 @property(atomic) NSMutableArray *unprocessedLogs;

--- a/MobileCenterCrashes/MobileCenterCrashes/Internals/MSWrapperExceptionManager.m
+++ b/MobileCenterCrashes/MobileCenterCrashes/Internals/MSWrapperExceptionManager.m
@@ -106,12 +106,12 @@
 }
 
 - (BOOL)hasException {
-  return _wrapperException != nil;
+  return self.wrapperException != nil;
 }
 
 - (MSException*)loadWrapperException:(CFUUIDRef)uuidRef {
-  if (_wrapperException && [[self class] isCurrentUUIDRef:uuidRef]) {
-    return _wrapperException;
+  if (self.wrapperException && [[self class] isCurrentUUIDRef:uuidRef]) {
+    return self.wrapperException;
   }
   NSString *filename = [[self class] getFilenameWithUUIDRef:uuidRef];
   if (![[NSFileManager defaultManager] fileExistsAtPath:filename]) {
@@ -124,16 +124,16 @@
     return nil;
   }
 
-  _wrapperException = loadedException;
-  _currentUUIDRef = uuidRef;
+  self.wrapperException = loadedException;
+  self.currentUUIDRef = uuidRef;
 
-  return _wrapperException;
+  return self.wrapperException;
 }
 
 - (void)saveWrapperException:(CFUUIDRef)uuidRef {
   NSString *filename = [[self class] getFilenameWithUUIDRef:uuidRef];
   [self saveWrapperExceptionData:uuidRef];
-  BOOL success = [NSKeyedArchiver archiveRootObject:_wrapperException toFile:filename];
+  BOOL success = [NSKeyedArchiver archiveRootObject:self.wrapperException toFile:filename];
   if (!success) {
     MSLogError([MSCrashes logTag], @"Failed to save file %@", filename);
   }
@@ -144,14 +144,14 @@
   [[self class] deleteFile:path];
 
   if ([[self class] isCurrentUUIDRef:uuidRef]) {
-    _currentUUIDRef = nil;
-    _wrapperException = nil;
+    self.currentUUIDRef = nil;
+    self.wrapperException = nil;
   }
 }
 
 - (void)deleteAllWrapperExceptions {
-  _currentUUIDRef = nil;
-  _wrapperException = nil;
+  self.currentUUIDRef = nil;
+  self.wrapperException = nil;
 
   NSFileManager *fileManager = [NSFileManager defaultManager];
 
@@ -164,16 +164,16 @@
 }
 
 - (void)saveWrapperExceptionData:(CFUUIDRef)uuidRef {
-  if (!_unsavedWrapperExceptionData) {
+  if (!self.unsavedWrapperExceptionData) {
     return;
   }
   NSString* dataFilename = [[self class] getDataFilenameWithUUIDRef:uuidRef];
-  [_unsavedWrapperExceptionData writeToFile:dataFilename atomically:YES];
+  [self.unsavedWrapperExceptionData writeToFile:dataFilename atomically:YES];
 }
 
 - (NSData*)loadWrapperExceptionDataWithUUIDString:(NSString*)uuidString {
   NSString *dataFilename = [[self class] getDataFilename:uuidString];
-  NSData *data = [_wrapperExceptionData objectForKey:dataFilename];
+  NSData *data = [self.wrapperExceptionData objectForKey:dataFilename];
   if (data) {
     return data;
   }
@@ -190,7 +190,7 @@
   NSString* dataFilename = [[self class] getDataFilename:uuidString];
   NSData *data = [self loadWrapperExceptionDataWithUUIDString:uuidString];
   if (data) {
-    [_wrapperExceptionData setObject:data forKey:dataFilename];
+    [self.wrapperExceptionData setObject:data forKey:dataFilename];
   }
   [[self class] deleteFile:dataFilename];
 }

--- a/MobileCenterCrashes/MobileCenterCrashes/Internals/Model/MSErrorReport.m
+++ b/MobileCenterCrashes/MobileCenterCrashes/Internals/Model/MSErrorReport.m
@@ -7,6 +7,12 @@
 
 NSString *const kMSErrorReportKillSignal = @"SIGKILL";
 
+@interface MSErrorReport()
+
+@property (nonatomic,copy) NSString *signal;
+
+@end
+
 @implementation MSErrorReport
 
 - (instancetype)initWithErrorId:(NSString *)errorId
@@ -36,7 +42,7 @@ NSString *const kMSErrorReportKillSignal = @"SIGKILL";
 - (BOOL)isAppKill {
   BOOL result = NO;
 
-  if (_signal && [[_signal uppercaseString] isEqualToString:kMSErrorReportKillSignal])
+  if (self.signal && [[self.signal uppercaseString] isEqualToString:kMSErrorReportKillSignal])
     result = YES;
 
   return result;

--- a/MobileCenterCrashes/MobileCenterCrashes/MSCrashes.mm
+++ b/MobileCenterCrashes/MobileCenterCrashes/MSCrashes.mm
@@ -83,6 +83,26 @@ static void uncaught_cxx_exception_handler(const MSCrashesUncaughtCXXExceptionIn
 
 @interface MSCrashes () <MSChannelDelegate, MSLogManagerDelegate>
 
+/**
+ * Indicates if the app crashed in the previous session
+ *
+ * Use this on startup, to check if the app starts the first time after it
+ crashed
+ * previously. You can use this also to disable specific events, like asking
+ * the user to rate your app.
+
+ * @warning This property only has a correct value, once the sdk has been
+ properly initialized!
+
+ * @see lastSessionCrashReport
+ */
+@property (atomic) BOOL didCrashInLastSession;
+
+/**
+ * Detail information about the last crash.
+ */
+@property(atomic, getter=getLastSessionCrashReport) MSErrorReport *lastSessionCrashReport;
+
 @end
 
 @implementation MSCrashes
@@ -218,7 +238,7 @@ static void uncaught_cxx_exception_handler(const MSCrashesUncaughtCXXExceptionIn
 
     // Get pending crashes from PLCrashReporter and persist them in the intermediate format.
     if ([self.plCrashReporter hasPendingCrashReport]) {
-      _didCrashInLastSession = YES;
+      self.didCrashInLastSession = YES;
       [self handleLatestCrashReport];
     }
 
@@ -363,7 +383,7 @@ static void uncaught_cxx_exception_handler(const MSCrashesUncaughtCXXExceptionIn
 #pragma mark - Crash reporter configuration
 
 - (void)configureCrashReporter {
-  if (_plCrashReporter) {
+  if (self.plCrashReporter) {
     MSLogDebug([MSCrashes logTag], @"Already configured PLCrashReporter.");
     return;
   }
@@ -376,7 +396,7 @@ static void uncaught_cxx_exception_handler(const MSCrashesUncaughtCXXExceptionIn
   PLCrashReporterSymbolicationStrategy symbolicationStrategy = PLCrashReporterSymbolicationStrategyNone;
   MSPLCrashReporterConfig *config = [[MSPLCrashReporterConfig alloc] initWithSignalHandlerType:signalHandlerType
                                                                          symbolicationStrategy:symbolicationStrategy];
-  _plCrashReporter = [[MSPLCrashReporter alloc] initWithConfiguration:config];
+  self.plCrashReporter = [[MSPLCrashReporter alloc] initWithConfiguration:config];
 
   /**
    * The actual signal and mach handlers are only registered when invoking
@@ -504,7 +524,7 @@ static void uncaught_cxx_exception_handler(const MSCrashesUncaughtCXXExceptionIn
   }
 
   // Get a user confirmation if there are crash logs that need to be processed.
-  if ([_unprocessedLogs count] > 0) {
+  if ([self.unprocessedLogs count] > 0) {
     NSNumber *flag = [MS_USER_DEFAULTS objectForKey:kMSUserConfirmationKey];
     if (flag && [flag boolValue]) {
 
@@ -513,7 +533,7 @@ static void uncaught_cxx_exception_handler(const MSCrashesUncaughtCXXExceptionIn
                  @"The flag for user confirmation is set to MSUserConfirmationAlways, continue sending logs");
       [MSCrashes notifyWithUserConfirmation:MSUserConfirmationSend];
       return;
-    } else if (!_userConfirmationHandler || !_userConfirmationHandler(_unprocessedReports)) {
+    } else if (!self.userConfirmationHandler || !self.userConfirmationHandler(self.unprocessedReports)) {
 
       // User confirmation handler doesn't exist or returned NO which means 'want to process'.
       MSLogDebug([MSCrashes logTag],
@@ -552,7 +572,7 @@ static void uncaught_cxx_exception_handler(const MSCrashesUncaughtCXXExceptionIn
   NSError *error = nil;
   for (NSString *filePath in [self.fileManager enumeratorAtPath:self.crashesDir]) {
     NSString *path = [self.crashesDir stringByAppendingPathComponent:filePath];
-    [_fileManager removeItemAtPath:path error:&error];
+    [self.fileManager removeItemAtPath:path error:&error];
     if (error) {
       MSLogError([MSCrashes logTag], @"Error deleting file %@: %@", filePath, error.localizedDescription);
     }
@@ -588,7 +608,7 @@ static void uncaught_cxx_exception_handler(const MSCrashesUncaughtCXXExceptionIn
       if (report) {
         NSString *cacheFilename = [NSString stringWithFormat:@"%.0f", [NSDate timeIntervalSinceReferenceDate]];
         [crashData writeToFile:[self.crashesDir stringByAppendingPathComponent:cacheFilename] atomically:YES];
-        _lastSessionCrashReport = [MSErrorLogFormatter errorReportFromCrashReport:report];
+        self.lastSessionCrashReport = [MSErrorLogFormatter errorReportFromCrashReport:report];
       } else {
         MSLogWarning([MSCrashes logTag], @"Could not parse crash report");
       }

--- a/MobileCenterCrashes/MobileCenterCrashes/MSCrashes.mm
+++ b/MobileCenterCrashes/MobileCenterCrashes/MSCrashes.mm
@@ -200,7 +200,7 @@ static void uncaught_cxx_exception_handler(const MSCrashesUncaughtCXXExceptionIn
     }
 
     // Get persisted crash reports.
-    _crashFiles = [self persistedCrashReports];
+    self.crashFiles = [self persistedCrashReports];
 
     // Set self as delegate of crashes' channel.
     [self.logManager addChannelDelegate:self forPriority:MSPriorityHigh];
@@ -440,9 +440,9 @@ static void uncaught_cxx_exception_handler(const MSCrashesUncaughtCXXExceptionIn
 
 - (void)processCrashReports {
   NSError *error = NULL;
-  _unprocessedLogs = [[NSMutableArray alloc] init];
-  _unprocessedReports = [[NSMutableArray alloc] init];
-  _unprocessedFilePaths = [[NSMutableArray alloc] init];
+  self.unprocessedLogs = [[NSMutableArray alloc] init];
+  self.unprocessedReports = [[NSMutableArray alloc] init];
+  self.unprocessedFilePaths = [[NSMutableArray alloc] init];
 
   NSArray *tempCrashesFiles = [NSArray arrayWithArray:self.crashFiles];
   for (NSString *filePath in tempCrashesFiles) {
@@ -463,9 +463,9 @@ static void uncaught_cxx_exception_handler(const MSCrashesUncaughtCXXExceptionIn
                      report.debugDescription);
 
           // Put the log to temporary space for next callbacks.
-          [_unprocessedLogs addObject:log];
-          [_unprocessedReports addObject:errorReport];
-          [_unprocessedFilePaths addObject:filePath];
+          [self.unprocessedLogs addObject:log];
+          [self.unprocessedReports addObject:errorReport];
+          [self.unprocessedFilePaths addObject:filePath];
 
           continue;
         } else {

--- a/MobileCenterCrashes/MobileCenterCrashes/MSCrashes.mm
+++ b/MobileCenterCrashes/MobileCenterCrashes/MSCrashes.mm
@@ -245,7 +245,7 @@ static void uncaught_cxx_exception_handler(const MSCrashesUncaughtCXXExceptionIn
     }
 
     // Get persisted crash reports.
-    _crashFiles = [self persistedCrashReports];
+    self.crashFiles = [self persistedCrashReports];
 
     // Set self as delegate of crashes' channel.
     [self.logManager addChannelDelegate:self forPriority:MSPriorityHigh];
@@ -763,6 +763,11 @@ static void uncaught_cxx_exception_handler(const MSCrashesUncaughtCXXExceptionIn
   } else {
     MSLogError([MSCrashes logTag], @"Could not load crash report: %@", error.localizedDescription);
   }
+}
+
+//We need override setter, because his default behavior create NSArray, and some tests fall
+- (void)setCrashFiles:(NSMutableArray *)crashFiles {
+  self->_crashFiles = [[NSMutableArray alloc] initWithArray:crashFiles];
 }
 
 @end


### PR DESCRIPTION
I created a special property for class MSCrashesCXXExceptionWrapperException.m, because I don't know an another way for fix warning.

Also I moved two properties from MSCrashesPrivate.h to MSCrashes.mm because this properties have been using only inside class MSCrashes and I found only this way for fix.

Let me know if you have other suggestion how I could fix it