### PR TITLE
Feature/cleanup header makros

### DIFF
--- a/Demo/Demo/Constants.h
+++ b/Demo/Demo/Constants.h
@@ -1,6 +1,1 @@
-#ifndef Constants_h
-#define Constants_h
-
 static NSString *const kDEMLogTag = @"[Demo]";
-
-#endif /* Constants_h */

--- a/MobileCenter/MobileCenter/Internals/Channel/MSChannel.h
+++ b/MobileCenter/MobileCenter/Internals/Channel/MSChannel.h
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import "MSChannelConfiguration.h"
 #import "MSConstants+Internal.h"
 #import "MSEnable.h"

--- a/MobileCenter/MobileCenter/Internals/Channel/MSChannelConfiguration.h
+++ b/MobileCenter/MobileCenter/Internals/Channel/MSChannelConfiguration.h
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import <Foundation/Foundation.h>
 
 #import "MSConstants+Internal.h"

--- a/MobileCenter/MobileCenter/Internals/Channel/MSChannelConfiguration.m
+++ b/MobileCenter/MobileCenter/Internals/Channel/MSChannelConfiguration.m
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import "MSChannelConfiguration.h"
 
 static MSChannelConfiguration *MSChannelConfigurationDefault;

--- a/MobileCenter/MobileCenter/Internals/Channel/MSChannelDefault.h
+++ b/MobileCenter/MobileCenter/Internals/Channel/MSChannelDefault.h
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import <Foundation/Foundation.h>
 
 #import "MSChannel.h"

--- a/MobileCenter/MobileCenter/Internals/Channel/MSChannelDefault.m
+++ b/MobileCenter/MobileCenter/Internals/Channel/MSChannelDefault.m
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import "MSChannelDefault.h"
 #import "MSMobileCenterErrors.h"
 #import "MSMobileCenterInternal.h"

--- a/MobileCenter/MobileCenter/Internals/Channel/MSChannelDelegate.h
+++ b/MobileCenter/MobileCenter/Internals/Channel/MSChannelDelegate.h
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import <Foundation/Foundation.h>
 #import "MSChannel.h"
 

--- a/MobileCenter/MobileCenter/Internals/Channel/MSLogManager.h
+++ b/MobileCenter/MobileCenter/Internals/Channel/MSLogManager.h
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import "../Model/MSLog.h"
 #import "MSEnable.h"
 #import "MSLogManagerDelegate.h"

--- a/MobileCenter/MobileCenter/Internals/Channel/MSLogManagerDefault.h
+++ b/MobileCenter/MobileCenter/Internals/Channel/MSLogManagerDefault.h
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import <Foundation/Foundation.h>
 
 #import "MSChannel.h"

--- a/MobileCenter/MobileCenter/Internals/Channel/MSLogManagerDefault.m
+++ b/MobileCenter/MobileCenter/Internals/Channel/MSLogManagerDefault.m
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import "MSChannelDefault.h"
 #import "MSLogManagerDefault.h"
 #import "MSLogManagerDefaultPrivate.h"

--- a/MobileCenter/MobileCenter/Internals/Channel/MSLogManagerDefaultPrivate.h
+++ b/MobileCenter/MobileCenter/Internals/Channel/MSLogManagerDefaultPrivate.h
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import <Foundation/Foundation.h>
 
 #import "MSChannel.h"

--- a/MobileCenter/MobileCenter/Internals/Channel/MSLogManagerDelegate.h
+++ b/MobileCenter/MobileCenter/Internals/Channel/MSLogManagerDelegate.h
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import "MSConstants+Internal.h"
 #import <Foundation/Foundation.h>
 

--- a/MobileCenter/MobileCenter/Internals/Device/MSDeviceTracker.h
+++ b/MobileCenter/MobileCenter/Internals/Device/MSDeviceTracker.h
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import "MSDevice.h"
 
 /**

--- a/MobileCenter/MobileCenter/Internals/Device/MSDeviceTracker.m
+++ b/MobileCenter/MobileCenter/Internals/Device/MSDeviceTracker.m
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import "MSConstants+Internal.h"
 #import "MSDeviceTracker.h"
 #import "MSDeviceTrackerPrivate.h"

--- a/MobileCenter/MobileCenter/Internals/Device/MSDeviceTrackerPrivate.h
+++ b/MobileCenter/MobileCenter/Internals/Device/MSDeviceTrackerPrivate.h
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import "MSDevice.h"
 #import "MSWrapperSdk.h"
 #import <CoreTelephony/CTCarrier.h>

--- a/MobileCenter/MobileCenter/Internals/MSEnable.h
+++ b/MobileCenter/MobileCenter/Internals/MSEnable.h
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import <Foundation/Foundation.h>
 
 /**

--- a/MobileCenter/MobileCenter/Internals/MSLogger.h
+++ b/MobileCenter/MobileCenter/Internals/MSLogger.h
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import "MSConstants.h"
 #import <Foundation/Foundation.h>
 

--- a/MobileCenter/MobileCenter/Internals/MSMobileCenterInternal.h
+++ b/MobileCenter/MobileCenter/Internals/MSMobileCenterInternal.h
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import "MSLogManager.h"
 #import "MSMobileCenter.h"
 #import "MSServiceInternal.h"

--- a/MobileCenter/MobileCenter/Internals/MSServiceAbstract.m
+++ b/MobileCenter/MobileCenter/Internals/MSServiceAbstract.m
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import "MSMobileCenterInternal.h"
 #import "MSServiceAbstractPrivate.h"
 

--- a/MobileCenter/MobileCenter/Internals/MSServiceAbstractInternal.h
+++ b/MobileCenter/MobileCenter/Internals/MSServiceAbstractInternal.h
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import "MSService.h"
 #import "MSServiceAbstract.h"
 #import "MSServiceCommon.h"

--- a/MobileCenter/MobileCenter/Internals/MSServiceAbstractPrivate.h
+++ b/MobileCenter/MobileCenter/Internals/MSServiceAbstractPrivate.h
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import "MSUserDefaults.h"
 #import <Foundation/Foundation.h>
 

--- a/MobileCenter/MobileCenter/Internals/MSServiceAbstractProtected.h
+++ b/MobileCenter/MobileCenter/Internals/MSServiceAbstractProtected.h
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 /**
  *  Protected declarations for MSServiceAbstract.
  */

--- a/MobileCenter/MobileCenter/Internals/MSServiceCommon.h
+++ b/MobileCenter/MobileCenter/Internals/MSServiceCommon.h
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import "MSLogManager.h"
 #import <Foundation/Foundation.h>
 

--- a/MobileCenter/MobileCenter/Internals/MSServiceInternal.h
+++ b/MobileCenter/MobileCenter/Internals/MSServiceInternal.h
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import "MSService.h"
 #import "MSServiceCommon.h"
 #import "MSLogManager.h"

--- a/MobileCenter/MobileCenter/Internals/MSWrapperLogger.h
+++ b/MobileCenter/MobileCenter/Internals/MSWrapperLogger.h
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import "MSConstants.h"
 #import <Foundation/Foundation.h>
 

--- a/MobileCenter/MobileCenter/Internals/MSWrapperLogger.m
+++ b/MobileCenter/MobileCenter/Internals/MSWrapperLogger.m
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import "MSWrapperLogger.h"
 #import "MSLogger.h"
 

--- a/MobileCenter/MobileCenter/Internals/MobileCenter+Internal.h
+++ b/MobileCenter/MobileCenter/Internals/MobileCenter+Internal.h
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import "MSServiceAbstractInternal.h"
 #import "MSServiceInternal.h"
 #import "MSLogger.h"
@@ -13,9 +9,6 @@
 #import "Model/MSLogWithProperties.h"
 #import "Model/Utils/MSUserDefaults.h"
 #import "MSWrapperSdk.h"
-#import "MSUtil.h"
-
-// Environment Helper
 #import "MSUtil.h"
 
 // Channel

--- a/MobileCenter/MobileCenter/Internals/Model/MSAbstractLog.h
+++ b/MobileCenter/MobileCenter/Internals/Model/MSAbstractLog.h
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import <Foundation/Foundation.h>
 
 #import "MSLog.h"

--- a/MobileCenter/MobileCenter/Internals/Model/MSAbstractLog.m
+++ b/MobileCenter/MobileCenter/Internals/Model/MSAbstractLog.m
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import "MSAbstractLog.h"
 #import "MSLogger.h"
 #import "MSDevice.h"

--- a/MobileCenter/MobileCenter/Internals/Model/MSDevicePrivate.h
+++ b/MobileCenter/MobileCenter/Internals/Model/MSDevicePrivate.h
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import "MSAbstractLog.h"
 #import <Foundation/Foundation.h>
 

--- a/MobileCenter/MobileCenter/Internals/Model/MSLog.h
+++ b/MobileCenter/MobileCenter/Internals/Model/MSLog.h
@@ -1,6 +1,4 @@
 /*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- *
  * OpenAPI spec version: 1.0.0-preview20160708
  */
 

--- a/MobileCenter/MobileCenter/Internals/Model/MSLogContainer.h
+++ b/MobileCenter/MobileCenter/Internals/Model/MSLogContainer.h
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import "MSLog.h"
 #import <Foundation/Foundation.h>
 

--- a/MobileCenter/MobileCenter/Internals/Model/MSLogContainer.m
+++ b/MobileCenter/MobileCenter/Internals/Model/MSLogContainer.m
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import "MSLogContainer.h"
 #import "MSSerializableObject.h"
 

--- a/MobileCenter/MobileCenter/Internals/Model/MSLogWithProperties.h
+++ b/MobileCenter/MobileCenter/Internals/Model/MSLogWithProperties.h
@@ -1,6 +1,4 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- *
+/**
  * OpenAPI spec version: 1.0.0-preview20160708
  */
 
@@ -9,7 +7,8 @@
 
 @interface MSLogWithProperties : MSAbstractLog
 
-/* Additional key/value pair parameters.  [optional]
+/** 
+ * Additional key/value pair parameters.  [optional]
  */
 @property(nonatomic) NSDictionary<NSString *, NSString *> *properties;
 

--- a/MobileCenter/MobileCenter/Internals/Model/MSLogWithProperties.m
+++ b/MobileCenter/MobileCenter/Internals/Model/MSLogWithProperties.m
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import "MSLogWithProperties.h"
 #import "MSLogger.h"
 #import "MSLogContainer.h"

--- a/MobileCenter/MobileCenter/Internals/Model/MSSerializableObject.h
+++ b/MobileCenter/MobileCenter/Internals/Model/MSSerializableObject.h
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import <Foundation/Foundation.h>
 
 @protocol MSSerializableObject <NSCoding>

--- a/MobileCenter/MobileCenter/Internals/Model/MSWrapperSdkPrivate.h
+++ b/MobileCenter/MobileCenter/Internals/Model/MSWrapperSdkPrivate.h
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import "MSAbstractLog.h"
 #import <Foundation/Foundation.h>
 

--- a/MobileCenter/MobileCenter/Internals/Model/Utils/MSUserDefaults.h
+++ b/MobileCenter/MobileCenter/Internals/Model/Utils/MSUserDefaults.h
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN

--- a/MobileCenter/MobileCenter/Internals/Model/Utils/MSUserDefaults.m
+++ b/MobileCenter/MobileCenter/Internals/Model/Utils/MSUserDefaults.m
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import "MSLogger.h"
 #import "MSUserDefaults.h"
 #import "MSMobileCenterInternal.h"

--- a/MobileCenter/MobileCenter/Internals/Sender/MSHttpSender.h
+++ b/MobileCenter/MobileCenter/Internals/Sender/MSHttpSender.h
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import "MSSender.h"
 #import <Foundation/Foundation.h>
 

--- a/MobileCenter/MobileCenter/Internals/Sender/MSHttpSender.m
+++ b/MobileCenter/MobileCenter/Internals/Sender/MSHttpSender.m
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import "MSHttpSender.h"
 #import "MSHttpSenderPrivate.h"
 #import "MSMobileCenterInternal.h"

--- a/MobileCenter/MobileCenter/Internals/Sender/MSHttpSenderPrivate.h
+++ b/MobileCenter/MobileCenter/Internals/Sender/MSHttpSenderPrivate.h
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import <Foundation/Foundation.h>
 
 static short const kMSMaxCharactersDisplayedForAppSecret = 8;

--- a/MobileCenter/MobileCenter/Internals/Sender/MSIngestionSender.h
+++ b/MobileCenter/MobileCenter/Internals/Sender/MSIngestionSender.h
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import <Foundation/Foundation.h>
 #import "MSHttpSender.h"
 

--- a/MobileCenter/MobileCenter/Internals/Sender/MSIngestionSender.m
+++ b/MobileCenter/MobileCenter/Internals/Sender/MSIngestionSender.m
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import "MSIngestionSender.h"
 #import "MobileCenter.h"
 #import "MSLogger.h"

--- a/MobileCenter/MobileCenter/Internals/Sender/MSSender.h
+++ b/MobileCenter/MobileCenter/Internals/Sender/MSSender.h
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import "MSEnable.h"
 #import "MSSenderCallDelegate.h"
 #import "MSSenderUtil.h"

--- a/MobileCenter/MobileCenter/Internals/Sender/MSSenderCall.h
+++ b/MobileCenter/MobileCenter/Internals/Sender/MSSenderCall.h
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import "MSSender.h"
 #import <Foundation/Foundation.h>
 

--- a/MobileCenter/MobileCenter/Internals/Sender/MSSenderCall.m
+++ b/MobileCenter/MobileCenter/Internals/Sender/MSSenderCall.m
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import "MSMobileCenterErrors.h"
 #import "MSMobileCenterInternal.h"
 #import "MSSenderCall.h"

--- a/MobileCenter/MobileCenter/Internals/Sender/MSSenderCallDelegate.h
+++ b/MobileCenter/MobileCenter/Internals/Sender/MSSenderCallDelegate.h
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import <Foundation/Foundation.h>
 
 @class MSSenderCall;

--- a/MobileCenter/MobileCenter/Internals/Sender/MSSenderDelegate.h
+++ b/MobileCenter/MobileCenter/Internals/Sender/MSSenderDelegate.h
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 @protocol MSSender;
 
 @protocol MSSenderDelegate <NSObject>

--- a/MobileCenter/MobileCenter/Internals/Sender/Utils/MSSenderUtil.h
+++ b/MobileCenter/MobileCenter/Internals/Sender/Utils/MSSenderUtil.h
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import <Foundation/Foundation.h>
 
 typedef void (^MSSendAsyncCompletionHandler)(NSString *batchId, NSError *error, NSUInteger statusCode);

--- a/MobileCenter/MobileCenter/Internals/Sender/Utils/MSSenderUtil.m
+++ b/MobileCenter/MobileCenter/Internals/Sender/Utils/MSSenderUtil.m
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import "MSSenderUtil.h"
 
 @implementation MSSenderUtil

--- a/MobileCenter/MobileCenter/Internals/Storage/MSFile.h
+++ b/MobileCenter/MobileCenter/Internals/Storage/MSFile.h
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN

--- a/MobileCenter/MobileCenter/Internals/Storage/MSFileStorage.h
+++ b/MobileCenter/MobileCenter/Internals/Storage/MSFileStorage.h
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import "MSStorage.h"
 #import "MSStorageBucket.h"
 #import <Foundation/Foundation.h>

--- a/MobileCenter/MobileCenter/Internals/Storage/MSFileUtil.h
+++ b/MobileCenter/MobileCenter/Internals/Storage/MSFileUtil.h
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import "MSFile.h"
 #import <Foundation/Foundation.h>
 

--- a/MobileCenter/MobileCenter/Internals/Storage/MSStorage.h
+++ b/MobileCenter/MobileCenter/Internals/Storage/MSStorage.h
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import "MSLog.h"
 #import "MSLogContainer.h"
 #import <Foundation/Foundation.h>

--- a/MobileCenter/MobileCenter/Internals/Storage/MSStorageBucket.h
+++ b/MobileCenter/MobileCenter/Internals/Storage/MSStorageBucket.h
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import "MSFile.h"
 #import "MSLog.h"
 #import <Foundation/Foundation.h>

--- a/MobileCenter/MobileCenter/Internals/Utils/MSConstants+Internal.h
+++ b/MobileCenter/MobileCenter/Internals/Utils/MSConstants+Internal.h
@@ -2,8 +2,6 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  */
 
-#ifndef MSConstants_Internal_h
-#define MSConstants_Internal_h
 #import <Foundation/Foundation.h>
 
 // Device manufacturer
@@ -127,5 +125,3 @@ typedef NS_ENUM(NSInteger, MSHTTPCodesNo) {
   MSHTTPCodesNo598NetworkReadTimeoutErrorUnknown = 598,
   MSHTTPCodesNo599NetworkConnectTimeoutErrorUnknown = 599
 };
-
-#endif /* MSConstants_Internal_h */

--- a/MobileCenter/MobileCenter/Internals/Utils/MSConstants+Internal.h
+++ b/MobileCenter/MobileCenter/Internals/Utils/MSConstants+Internal.h
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import <Foundation/Foundation.h>
 
 // Device manufacturer

--- a/MobileCenter/MobileCenter/Internals/Utils/MSKeychainUtil.h
+++ b/MobileCenter/MobileCenter/Internals/Utils/MSKeychainUtil.h
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 

--- a/MobileCenter/MobileCenter/Internals/Utils/MSKeychainUtil.m
+++ b/MobileCenter/MobileCenter/Internals/Utils/MSKeychainUtil.m
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import <Foundation/Foundation.h>
 #import "MSKeychainUtil.h"
 

--- a/MobileCenter/MobileCenter/Internals/Utils/MSUtil.h
+++ b/MobileCenter/MobileCenter/Internals/Utils/MSUtil.h
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 

--- a/MobileCenter/MobileCenter/Internals/Utils/MSUtil.h
+++ b/MobileCenter/MobileCenter/Internals/Utils/MSUtil.h
@@ -5,9 +5,6 @@
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
-#ifndef MSUtil_h
-#define MSUtil_h
-
 #define MS_USER_DEFAULTS [MSUserDefaults shared]
 #define MS_NOTIFICATION_CENTER [NSNotificationCenter defaultCenter]
 #define MS_DEVICE [UIDevice currentDevice]
@@ -16,7 +13,6 @@
 #define MS_LOCALE [NSLocale currentLocale]
 #define MS_CLASS_NAME_WITHOUT_PREFIX [NSStringFromClass([self class]) substringFromIndex:2]
 #define MS_IS_APP_EXTENSION [[[NSBundle mainBundle] executablePath] containsString:@".appex/"]
-#endif /* MSUtil_h */
 
 
 /**

--- a/MobileCenter/MobileCenter/Internals/Utils/MSUtilPrivate.h
+++ b/MobileCenter/MobileCenter/Internals/Utils/MSUtilPrivate.h
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import "MSUtil.h"
 
 #import <UIKit/UIKit.h>

--- a/MobileCenter/MobileCenter/MSConstants.h
+++ b/MobileCenter/MobileCenter/MSConstants.h
@@ -1,8 +1,6 @@
 /*
  * Copyright (c) Microsoft Corporation. All rights reserved.
  */
-#ifndef MS_Constants_h
-#define MS_Constants_h
 #import <Foundation/Foundation.h>
 
 /**
@@ -43,11 +41,10 @@ typedef NS_ENUM(NSUInteger, MSLogLevel) {
   /**
    *  Logging is disabled
    */
-  MSLogLevelNone = 99,
+  MSLogLevelNone = 99
 };
 
 typedef NSString * (^MSLogMessageProvider)(void);
 typedef void (^MSLogHandler)(MSLogMessageProvider messageProvider, MSLogLevel logLevel, NSString *tag, const char *file,
                              const char *function, uint line);
 
-#endif

--- a/MobileCenter/MobileCenter/MSConstants.h
+++ b/MobileCenter/MobileCenter/MSConstants.h
@@ -1,6 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
 #import <Foundation/Foundation.h>
 
 /**

--- a/MobileCenter/MobileCenter/MSDevice.h
+++ b/MobileCenter/MobileCenter/MSDevice.h
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import "MSWrapperSdk.h"
 #import <Foundation/Foundation.h>
 

--- a/MobileCenter/MobileCenter/MSDevice.m
+++ b/MobileCenter/MobileCenter/MSDevice.m
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import "MSDevice.h"
 #import "MSDevicePrivate.h"
 #import "MSWrapperSdkPrivate.h"

--- a/MobileCenter/MobileCenter/MSMobileCenter.h
+++ b/MobileCenter/MobileCenter/MSMobileCenter.h
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import "MSConstants.h"
 #import <Foundation/Foundation.h>
 

--- a/MobileCenter/MobileCenter/MSService.h
+++ b/MobileCenter/MobileCenter/MSService.h
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import <Foundation/Foundation.h>
 
 /**

--- a/MobileCenter/MobileCenter/MSServiceAbstract.h
+++ b/MobileCenter/MobileCenter/MSServiceAbstract.h
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import "MSService.h"
 #import <Foundation/Foundation.h>
 

--- a/MobileCenter/MobileCenter/MSWrapperSdk.h
+++ b/MobileCenter/MobileCenter/MSWrapperSdk.h
@@ -1,7 +1,3 @@
-/*
-    * Copyright (c) Microsoft Corporation. All rights reserved.
-    */
-
 #import <Foundation/Foundation.h>
 
 @interface MSWrapperSdk : NSObject

--- a/MobileCenter/MobileCenter/MSWrapperSdk.m
+++ b/MobileCenter/MobileCenter/MSWrapperSdk.m
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import "MSWrapperSdk.h"
 #import "MSWrapperSdkPrivate.h"
 

--- a/MobileCenter/MobileCenter/MobileCenter.h
+++ b/MobileCenter/MobileCenter/MobileCenter.h
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import <Foundation/Foundation.h>
 
 #import "MSConstants.h"

--- a/MobileCenterAnalytics/MobileCenterAnalytics/Internals/MSAnalyticsDelegate.h
+++ b/MobileCenterAnalytics/MobileCenterAnalytics/Internals/MSAnalyticsDelegate.h
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import <Foundation/Foundation.h>
 
 @class MSEventLog;

--- a/MobileCenterAnalytics/MobileCenterAnalytics/Internals/MSAnalyticsInternal.h
+++ b/MobileCenterAnalytics/MobileCenterAnalytics/Internals/MSAnalyticsInternal.h
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import "MSAnalytics.h"
 #import "MSServiceInternal.h"
 #import "MSAnalyticsDelegate.h"

--- a/MobileCenterAnalytics/MobileCenterAnalytics/Internals/MSAnalyticsPrivate.h
+++ b/MobileCenterAnalytics/MobileCenterAnalytics/Internals/MSAnalyticsPrivate.h
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import "MSAnalytics.h"
 #import "MSServiceInternal.h"
 #import "MSSessionTracker.h"

--- a/MobileCenterAnalytics/MobileCenterAnalytics/Internals/Model/MSEventLog.h
+++ b/MobileCenterAnalytics/MobileCenterAnalytics/Internals/Model/MSEventLog.h
@@ -1,6 +1,4 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- *
+/**
  * OpenAPI spec version: 1.0.0-preview20160708
  */
 
@@ -9,7 +7,7 @@
 
 @interface MSEventLog : MSLogWithProperties
 
-/** 
+/**
  * Unique identifier for this event.
  */
 @property(nonatomic, copy) NSString *eventId;

--- a/MobileCenterAnalytics/MobileCenterAnalytics/Internals/Model/MSEventLog.m
+++ b/MobileCenterAnalytics/MobileCenterAnalytics/Internals/Model/MSEventLog.m
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import "MSEventLog.h"
 
 static NSString *const kMSTypeEvent = @"event";

--- a/MobileCenterAnalytics/MobileCenterAnalytics/Internals/Model/MSPageLog.h
+++ b/MobileCenterAnalytics/MobileCenterAnalytics/Internals/Model/MSPageLog.h
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import "MobileCenter+Internal.h"
 #import <Foundation/Foundation.h>
 

--- a/MobileCenterAnalytics/MobileCenterAnalytics/Internals/Model/MSPageLog.m
+++ b/MobileCenterAnalytics/MobileCenterAnalytics/Internals/Model/MSPageLog.m
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import "MSPageLog.h"
 
 static NSString *const kMSTypePage = @"page";

--- a/MobileCenterAnalytics/MobileCenterAnalytics/Internals/Model/MSStartSessionLog.h
+++ b/MobileCenterAnalytics/MobileCenterAnalytics/Internals/Model/MSStartSessionLog.h
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import "MobileCenter+Internal.h"
 #import <Foundation/Foundation.h>
 

--- a/MobileCenterAnalytics/MobileCenterAnalytics/Internals/Model/MSStartSessionLog.m
+++ b/MobileCenterAnalytics/MobileCenterAnalytics/Internals/Model/MSStartSessionLog.m
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import "MSStartSessionLog.h"
 
 static NSString *const kMSTypeEndSession = @"start_session";

--- a/MobileCenterAnalytics/MobileCenterAnalytics/Internals/Session/MSSessionHistoryInfo.h
+++ b/MobileCenterAnalytics/MobileCenterAnalytics/Internals/Session/MSSessionHistoryInfo.h
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import <Foundation/Foundation.h>
 
 @interface MSSessionHistoryInfo : NSObject <NSCoding>

--- a/MobileCenterAnalytics/MobileCenterAnalytics/Internals/Session/MSSessionHistoryInfo.m
+++ b/MobileCenterAnalytics/MobileCenterAnalytics/Internals/Session/MSSessionHistoryInfo.m
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import "MSSessionHistoryInfo.h"
 
 static NSString *const kMSSessionIdKey = @"sessionIdKey";

--- a/MobileCenterAnalytics/MobileCenterAnalytics/Internals/Session/MSSessionTracker.h
+++ b/MobileCenterAnalytics/MobileCenterAnalytics/Internals/Session/MSSessionTracker.h
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import "MSSessionHistoryInfo.h"
 #import "MSSessionTrackerDelegate.h"
 #import "MobileCenter+Internal.h"

--- a/MobileCenterAnalytics/MobileCenterAnalytics/Internals/Session/MSSessionTracker.m
+++ b/MobileCenterAnalytics/MobileCenterAnalytics/Internals/Session/MSSessionTracker.m
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import "MSAnalyticsInternal.h"
 #import "MSUtil.h"
 #import "MSSessionTracker.h"

--- a/MobileCenterAnalytics/MobileCenterAnalytics/Internals/Session/MSSessionTrackerDelegate.h
+++ b/MobileCenterAnalytics/MobileCenterAnalytics/Internals/Session/MSSessionTrackerDelegate.h
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import "MobileCenter+Internal.h"
 #import <Foundation/Foundation.h>
 

--- a/MobileCenterAnalytics/MobileCenterAnalytics/Internals/Utils/MSAnalyticsCategory.h
+++ b/MobileCenterAnalytics/MobileCenterAnalytics/Internals/Utils/MSAnalyticsCategory.h
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 

--- a/MobileCenterAnalytics/MobileCenterAnalytics/Internals/Utils/MSAnalyticsCategory.m
+++ b/MobileCenterAnalytics/MobileCenterAnalytics/Internals/Utils/MSAnalyticsCategory.m
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import "MSAnalyticsCategory.h"
 #import "MSAnalyticsInternal.h"
 #import <objc/runtime.h>

--- a/MobileCenterAnalytics/MobileCenterAnalytics/MSAnalytics.h
+++ b/MobileCenterAnalytics/MobileCenterAnalytics/MSAnalytics.h
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import "MSServiceAbstract.h"
 #import <UIKit/UIKit.h>
 

--- a/MobileCenterAnalytics/MobileCenterAnalytics/MSAnalytics.m
+++ b/MobileCenterAnalytics/MobileCenterAnalytics/MSAnalytics.m
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import "MSAnalytics.h"
 #import "MSAnalyticsCategory.h"
 #import "MSAnalyticsPrivate.h"

--- a/MobileCenterAnalytics/MobileCenterAnalytics/MobileCenterAnalytics.h
+++ b/MobileCenterAnalytics/MobileCenterAnalytics/MobileCenterAnalytics.h
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import <Foundation/Foundation.h>
 
 #import "MSAnalytics.h"

--- a/MobileCenterCrashes/MobileCenterCrashes/Internals/MSCrashesCXXExceptionHandler.h
+++ b/MobileCenterCrashes/MobileCenterCrashes/Internals/MSCrashesCXXExceptionHandler.h
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import <Foundation/Foundation.h>
 
 /**

--- a/MobileCenterCrashes/MobileCenterCrashes/Internals/MSCrashesCXXExceptionWrapperException.h
+++ b/MobileCenterCrashes/MobileCenterCrashes/Internals/MSCrashesCXXExceptionWrapperException.h
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import "MSCrashesCXXExceptionHandler.h"
 #import <Foundation/Foundation.h>
 

--- a/MobileCenterCrashes/MobileCenterCrashes/Internals/MSCrashesCXXExceptionWrapperException.m
+++ b/MobileCenterCrashes/MobileCenterCrashes/Internals/MSCrashesCXXExceptionWrapperException.m
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import "MSCrashesCXXExceptionWrapperException.h"
 
 @implementation MSCrashesCXXExceptionWrapperException {

--- a/MobileCenterCrashes/MobileCenterCrashes/Internals/MSCrashesInternal.h
+++ b/MobileCenterCrashes/MobileCenterCrashes/Internals/MSCrashesInternal.h
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import "MSCrashes.h"
 #import "MSServiceInternal.h"
 

--- a/MobileCenterCrashes/MobileCenterCrashes/Internals/MSCrashesPrivate.h
+++ b/MobileCenterCrashes/MobileCenterCrashes/Internals/MSCrashesPrivate.h
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import "MSCrashes.h"
 #import <CrashReporter/CrashReporter.h>
 

--- a/MobileCenterCrashes/MobileCenterCrashes/Internals/MSWrapperExceptionManager.h
+++ b/MobileCenterCrashes/MobileCenterCrashes/Internals/MSWrapperExceptionManager.h
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import <Foundation/Foundation.h>
 
 @class MSException;

--- a/MobileCenterCrashes/MobileCenterCrashes/Internals/MSWrapperExceptionManager.m
+++ b/MobileCenterCrashes/MobileCenterCrashes/Internals/MSWrapperExceptionManager.m
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import "MSWrapperExceptionManagerInternal.h"
 #import "MSCrashes.h"
 #import "MSException.h"

--- a/MobileCenterCrashes/MobileCenterCrashes/Internals/MSWrapperExceptionManagerInternal.h
+++ b/MobileCenterCrashes/MobileCenterCrashes/Internals/MSWrapperExceptionManagerInternal.h
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import "MSWrapperExceptionManager.h"
 
 @interface MSWrapperExceptionManager ()

--- a/MobileCenterCrashes/MobileCenterCrashes/Internals/Model/MSAbstractErrorLog.h
+++ b/MobileCenterCrashes/MobileCenterCrashes/Internals/Model/MSAbstractErrorLog.h
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import "MobileCenter+Internal.h"
 #import <Foundation/Foundation.h>
 

--- a/MobileCenterCrashes/MobileCenterCrashes/Internals/Model/MSAbstractErrorLog.m
+++ b/MobileCenterCrashes/MobileCenterCrashes/Internals/Model/MSAbstractErrorLog.m
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import "MSAbstractErrorLog.h"
 #import "MSErrorAttachment.h"
 #import "MSErrorAttachmentPrivate.h"

--- a/MobileCenterCrashes/MobileCenterCrashes/Internals/Model/MSAppleErrorLog.h
+++ b/MobileCenterCrashes/MobileCenterCrashes/Internals/Model/MSAppleErrorLog.h
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import "MSAbstractErrorLog.h"
 #import "MobileCenter+Internal.h"
 #import <Foundation/Foundation.h>

--- a/MobileCenterCrashes/MobileCenterCrashes/Internals/Model/MSAppleErrorLog.m
+++ b/MobileCenterCrashes/MobileCenterCrashes/Internals/Model/MSAppleErrorLog.m
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import "MSAppleErrorLog.h"
 #import "MSBinary.h"
 #import "MSException.h"

--- a/MobileCenterCrashes/MobileCenterCrashes/Internals/Model/MSBinary.h
+++ b/MobileCenterCrashes/MobileCenterCrashes/Internals/Model/MSBinary.h
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import "MobileCenter+Internal.h"
 #import <Foundation/Foundation.h>
 

--- a/MobileCenterCrashes/MobileCenterCrashes/Internals/Model/MSBinary.m
+++ b/MobileCenterCrashes/MobileCenterCrashes/Internals/Model/MSBinary.m
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import "MSBinary.h"
 
 static NSString *const kMSId = @"id";

--- a/MobileCenterCrashes/MobileCenterCrashes/Internals/Model/MSErrorAttachment.h
+++ b/MobileCenterCrashes/MobileCenterCrashes/Internals/Model/MSErrorAttachment.h
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import <Foundation/Foundation.h>
 
 @class MSErrorBinaryAttachment;

--- a/MobileCenterCrashes/MobileCenterCrashes/Internals/Model/MSErrorAttachment.m
+++ b/MobileCenterCrashes/MobileCenterCrashes/Internals/Model/MSErrorAttachment.m
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import "MSErrorAttachment.h"
 #import "MSErrorAttachmentPrivate.h"
 #import "MSErrorBinaryAttachment.h"

--- a/MobileCenterCrashes/MobileCenterCrashes/Internals/Model/MSErrorAttachmentPrivate.h
+++ b/MobileCenterCrashes/MobileCenterCrashes/Internals/Model/MSErrorAttachmentPrivate.h
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import "MobileCenter+Internal.h"
 
 @interface MSErrorAttachment ()  <MSSerializableObject>

--- a/MobileCenterCrashes/MobileCenterCrashes/Internals/Model/MSErrorBinaryAttachment.h
+++ b/MobileCenterCrashes/MobileCenterCrashes/Internals/Model/MSErrorBinaryAttachment.h
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import <Foundation/Foundation.h>
 
 /*

--- a/MobileCenterCrashes/MobileCenterCrashes/Internals/Model/MSErrorBinaryAttachment.m
+++ b/MobileCenterCrashes/MobileCenterCrashes/Internals/Model/MSErrorBinaryAttachment.m
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import "MSErrorBinaryAttachment.h"
 
 static NSString *const kMSFilename = @"file_name";

--- a/MobileCenterCrashes/MobileCenterCrashes/Internals/Model/MSErrorBinaryAttachmentPrivate.h
+++ b/MobileCenterCrashes/MobileCenterCrashes/Internals/Model/MSErrorBinaryAttachmentPrivate.h
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import "MobileCenter+Internal.h"
 
 @interface MSErrorBinaryAttachment ()  <MSSerializableObject>

--- a/MobileCenterCrashes/MobileCenterCrashes/Internals/Model/MSErrorReport.h
+++ b/MobileCenterCrashes/MobileCenterCrashes/Internals/Model/MSErrorReport.h
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import <Foundation/Foundation.h>
 @class MSDevice;
 

--- a/MobileCenterCrashes/MobileCenterCrashes/Internals/Model/MSErrorReport.m
+++ b/MobileCenterCrashes/MobileCenterCrashes/Internals/Model/MSErrorReport.m
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import "MSErrorReport.h"
 #import "MSErrorReportPrivate.h"
 

--- a/MobileCenterCrashes/MobileCenterCrashes/Internals/Model/MSErrorReportPrivate.h
+++ b/MobileCenterCrashes/MobileCenterCrashes/Internals/Model/MSErrorReportPrivate.h
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import "MSErrorReport.h"
 
 extern NSString *const __attribute__((unused)) kMSErrorReportKillSignal;

--- a/MobileCenterCrashes/MobileCenterCrashes/Internals/Model/MSException.h
+++ b/MobileCenterCrashes/MobileCenterCrashes/Internals/Model/MSException.h
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import "MobileCenter+Internal.h"
 #import <Foundation/Foundation.h>
 

--- a/MobileCenterCrashes/MobileCenterCrashes/Internals/Model/MSException.m
+++ b/MobileCenterCrashes/MobileCenterCrashes/Internals/Model/MSException.m
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import "MSException.h"
 #import "MSStackFrame.h"
 

--- a/MobileCenterCrashes/MobileCenterCrashes/Internals/Model/MSStackFrame.h
+++ b/MobileCenterCrashes/MobileCenterCrashes/Internals/Model/MSStackFrame.h
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import "MobileCenter+Internal.h"
 #import <Foundation/Foundation.h>
 

--- a/MobileCenterCrashes/MobileCenterCrashes/Internals/Model/MSStackFrame.m
+++ b/MobileCenterCrashes/MobileCenterCrashes/Internals/Model/MSStackFrame.m
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import "MSStackFrame.h"
 
 static NSString *const kMSAddress = @"address";

--- a/MobileCenterCrashes/MobileCenterCrashes/Internals/Model/MSThread.h
+++ b/MobileCenterCrashes/MobileCenterCrashes/Internals/Model/MSThread.h
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import "MobileCenter+Internal.h"
 #import <Foundation/Foundation.h>
 

--- a/MobileCenterCrashes/MobileCenterCrashes/Internals/Model/MSThread.m
+++ b/MobileCenterCrashes/MobileCenterCrashes/Internals/Model/MSThread.m
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import "MSException.h"
 #import "MSStackFrame.h"
 #import "MSThread.h"

--- a/MobileCenterCrashes/MobileCenterCrashes/Internals/Utils/MSCrashesUtil.h
+++ b/MobileCenterCrashes/MobileCenterCrashes/Internals/Utils/MSCrashesUtil.h
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import <Foundation/Foundation.h>
 
 @interface MSCrashesUtil : NSObject

--- a/MobileCenterCrashes/MobileCenterCrashes/Internals/Utils/MSCrashesUtil.m
+++ b/MobileCenterCrashes/MobileCenterCrashes/Internals/Utils/MSCrashesUtil.m
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import "MSCrashesUtil.h"
 
 static NSString *const kMSCrashesDirectory = @"com.microsoft.azure.mobile.mobilecenter/crashes";

--- a/MobileCenterCrashes/MobileCenterCrashes/Internals/Utils/MSErrorLogFormatter.h
+++ b/MobileCenterCrashes/MobileCenterCrashes/Internals/Utils/MSErrorLogFormatter.h
@@ -1,12 +1,8 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import <Foundation/Foundation.h>
 
 @class MSAppleErrorLog;
-@class MSPLCrashReport;
 @class MSErrorReport;
+@class MSPLCrashReport;
 
 /**
  *  Error logging error domain

--- a/MobileCenterCrashes/MobileCenterCrashes/Internals/Utils/MSErrorLogFormatterPrivate.h
+++ b/MobileCenterCrashes/MobileCenterCrashes/Internals/Utils/MSErrorLogFormatterPrivate.h
@@ -5,9 +5,6 @@
 #import "MSErrorLogFormatter.h"
 @class MSPLCrashReportThreadInfo;
 
-#ifndef MSErrorLogFormatterPrivate_h
-#define MSErrorLogFormatterPrivate_h
-
 @interface MSErrorLogFormatter ()
 
 /**
@@ -47,5 +44,3 @@
 + (MSPLCrashReportThreadInfo *)findCrashedThreadInReport:(MSPLCrashReport *)report;
 
 @end
-
-#endif /* MSErrorLogFormatterPrivate_h */

--- a/MobileCenterCrashes/MobileCenterCrashes/Internals/Utils/MSErrorLogFormatterPrivate.h
+++ b/MobileCenterCrashes/MobileCenterCrashes/Internals/Utils/MSErrorLogFormatterPrivate.h
@@ -1,8 +1,5 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import "MSErrorLogFormatter.h"
+
 @class MSPLCrashReportThreadInfo;
 
 @interface MSErrorLogFormatter ()

--- a/MobileCenterCrashes/MobileCenterCrashes/MSCrashes.h
+++ b/MobileCenterCrashes/MobileCenterCrashes/MSCrashes.h
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import "MSErrorReport.h"
 #import "MSServiceAbstract.h"
 

--- a/MobileCenterCrashes/MobileCenterCrashes/MSCrashes.mm
+++ b/MobileCenterCrashes/MobileCenterCrashes/MSCrashes.mm
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import "MSAppleErrorLog.h"
 #import "MSCrashesCXXExceptionWrapperException.h"
 #import "MSCrashesDelegate.h"

--- a/MobileCenterCrashes/MobileCenterCrashes/MSCrashesDelegate.h
+++ b/MobileCenterCrashes/MobileCenterCrashes/MSCrashesDelegate.h
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import <Foundation/Foundation.h>
 
 @class MSCrashes;

--- a/MobileCenterCrashes/MobileCenterCrashes/MobileCenterCrashes.h
+++ b/MobileCenterCrashes/MobileCenterCrashes/MobileCenterCrashes.h
@@ -1,7 +1,3 @@
-/*
- * Copyright (c) Microsoft Corporation. All rights reserved.
- */
-
 #import <Foundation/Foundation.h>
 
 #import "MSCrashes.h"

--- a/Puppet/Puppet/Constants.h
+++ b/Puppet/Puppet/Constants.h
@@ -2,9 +2,4 @@
  * Copyright (c) Microsoft Corporation. All rights reserved.
  */
 
-#ifndef Constants_h
-#define Constants_h
-
 static NSString *const kPUPLogTag = @"[Puppet]";
-
-#endif /* Constants_h */


### PR DESCRIPTION
This PR does two things:
1. removes `#ifndef` where applicable as we don't need them to have a unified style
2. Remove the copyright notices as we have a license file in our repo.