### PR TITLE
Check expection error first

### DIFF
--- a/MobileCenter/MobileCenterTests/MSIngestionSenderTests.m
+++ b/MobileCenter/MobileCenterTests/MSIngestionSenderTests.m
@@ -292,6 +292,9 @@ static NSString *const kMSAppSecret = @"mockAppSecret";
   // Then
   [self waitForExpectationsWithTimeout:kMSTestTimeout
                                handler:^(NSError *error) {
+                                 if (error) {
+                                   XCTFail(@"Expectation Failed with error: %@", error);
+                                 }
 
                                  // Must be only two tasks
                                  assertThatInteger(tasks.count, equalToInteger(2));
@@ -307,10 +310,6 @@ static NSString *const kMSAppSecret = @"mockAppSecret";
 
                                  // Calls must still be in the pending calls, not yet timed out.
                                  assertThatUnsignedLong(self.sut.pendingCalls.count, equalToInt(2));
-
-                                 if (error) {
-                                   XCTFail(@"Expectation Failed with error: %@", error);
-                                 }
                                }];
 }
 


### PR DESCRIPTION
As a part of investigation, I moved the error checking assert to the top.