### PR TITLE
Improve MSSessionTracker

### DIFF
--- a/MobileCenterAnalytics/MobileCenterAnalytics/Internals/Session/MSSessionHistoryInfo.h
+++ b/MobileCenterAnalytics/MobileCenterAnalytics/Internals/Session/MSSessionHistoryInfo.h
@@ -3,6 +3,14 @@
 @interface MSSessionHistoryInfo : NSObject <NSCoding>
 
 /**
+ * Initializes a new `MSSessionHistoryInfo` instance.
+ *
+ * @param toffset Time offset
+ * @param sessionId Session Id
+ */
+- (instancetype)initWithTOffset:(NSNumber *)toffset andSessionId:(NSString *)sessionId;
+
+/**
  *  Session Id.
  */
 @property(nonatomic, copy) NSString *sessionId;

--- a/MobileCenterAnalytics/MobileCenterAnalytics/Internals/Session/MSSessionHistoryInfo.m
+++ b/MobileCenterAnalytics/MobileCenterAnalytics/Internals/Session/MSSessionHistoryInfo.m
@@ -23,4 +23,13 @@ static NSString *const kMSToffsetKey = @"toffsetKey";
   [coder encodeObject:self.toffset forKey:kMSToffsetKey];
 }
 
+- (instancetype)initWithTOffset:(NSNumber *)toffset andSessionId:(NSString *)sessionId {
+  self = [super init];
+  if (self) {
+    _sessionId = sessionId;
+    _toffset = toffset;
+  }
+  return self;
+}
+
 @end

--- a/MobileCenterAnalytics/MobileCenterAnalytics/Internals/Session/MSSessionTracker.m
+++ b/MobileCenterAnalytics/MobileCenterAnalytics/Internals/Session/MSSessionTracker.m
@@ -186,8 +186,6 @@ static NSUInteger const kMSMaxSessionHistoryCount = 5;
                            inSortedRange:NSMakeRange(0, self.pastSessions.count)
                                  options:(NSBinarySearchingFirstEqual|NSBinarySearchingInsertionIndex)
                          usingComparator:^(id a, id b) {
-                           NSLog(@"a offset: %@", ((MSSessionHistoryInfo *)a).toffset);
-                           NSLog(@"b offset: %@", ((MSSessionHistoryInfo *)b).toffset);
                            return [((MSSessionHistoryInfo *)a).toffset compare:((MSSessionHistoryInfo *)b).toffset];
                          }];
 
@@ -199,9 +197,10 @@ static NSUInteger const kMSMaxSessionHistoryCount = 5;
     // All toffsets are smaller.
     else if (index == self.pastSessions.count) {
       log.sid = [self.pastSessions lastObject].sessionId;
-    } else {
+    }
 
-      // Either the pastSessions contains the exact toffset or we pick the smallest delta.
+    // Either the pastSessions contains the exact toffset or we pick the smallest delta.
+    else {
       long long leftDifference = [log.toffset longLongValue] - [self.pastSessions[index - 1].toffset longLongValue];
       long long rightDifference = [self.pastSessions[index].toffset longLongValue] - [log.toffset longLongValue];
       if (leftDifference < rightDifference) {

--- a/MobileCenterAnalytics/MobileCenterAnalytics/Internals/Session/MSSessionTracker.m
+++ b/MobileCenterAnalytics/MobileCenterAnalytics/Internals/Session/MSSessionTracker.m
@@ -179,14 +179,36 @@ static NSUInteger const kMSMaxSessionHistoryCount = 5;
     return;
 
   // Attach corresponding session id.
-  if (log.toffset != nil) {
-    [self.pastSessions
-        enumerateObjectsUsingBlock:^(MSSessionHistoryInfo *_Nonnull obj, NSUInteger idx, BOOL *_Nonnull stop) {
-          if ([log.toffset compare:obj.toffset] == NSOrderedDescending) {
-            log.sid = obj.sessionId;
-            *stop = YES;
-          }
-        }];
+  if (log.toffset) {
+    MSSessionHistoryInfo *find = [[MSSessionHistoryInfo alloc] initWithTOffset:log.toffset andSessionId:nil];
+    NSUInteger index =
+        [self.pastSessions indexOfObject:find
+                           inSortedRange:NSMakeRange(0, self.pastSessions.count)
+                                 options:(NSBinarySearchingFirstEqual|NSBinarySearchingInsertionIndex)
+                         usingComparator:^(id a, id b) {
+                           NSLog(@"a offset: %@", ((MSSessionHistoryInfo *)a).toffset);
+                           NSLog(@"b offset: %@", ((MSSessionHistoryInfo *)b).toffset);
+                           return [((MSSessionHistoryInfo *)a).toffset compare:((MSSessionHistoryInfo *)b).toffset];
+                         }];
+
+    // All toffsets are larger.
+    if (index == 0) {
+      log.sid = self.sessionId;
+    }
+
+    // All toffsets are smaller.
+    else if (index == self.pastSessions.count) {
+      log.sid = [self.pastSessions lastObject].sessionId;
+    } else {
+
+      // Either the pastSessions contains the exact toffset or we pick the smallest delta.
+      long long leftDifference = [log.toffset longLongValue] - [self.pastSessions[index - 1].toffset longLongValue];
+      long long rightDifference = [self.pastSessions[index].toffset longLongValue] - [log.toffset longLongValue];
+      if (leftDifference < rightDifference) {
+        --index;
+      }
+      log.sid = self.pastSessions[index].sessionId;
+    }
   }
 
   // If log is not correlated to a past session.

--- a/MobileCenterAnalytics/MobileCenterAnalyticsTests/MSSessionTrackerTests.m
+++ b/MobileCenterAnalytics/MobileCenterAnalyticsTests/MSSessionTrackerTests.m
@@ -196,4 +196,38 @@ NSTimeInterval const kMSTestSessionTimeout = 1.5;
                             withPriority:MSPriorityDefault]);
 }
 
+- (void)testOnProcessingLogWithPriority {
+
+  // When
+  MSLogWithProperties *log = [MSLogWithProperties new];
+
+  // Then
+  XCTAssertNil(log.sid);
+  XCTAssertNil(log.toffset);
+
+  [self.sut onProcessingLog:log withPriority:MSPriorityDefault];
+
+  // And then
+  XCTAssertNil(log.toffset);
+  XCTAssertEqual(log.sid, self.sut.sessionId);
+
+  // When
+  log.toffset = 0;
+
+  [self.sut onProcessingLog:log withPriority:MSPriorityDefault];
+
+  // Then
+  XCTAssertEqual(0, log.toffset.integerValue);
+  XCTAssertEqual(log.sid, [self.sut.pastSessions firstObject].sessionId);
+
+  // When
+  log.toffset = [NSNumber numberWithUnsignedLongLong:UINT64_MAX];
+
+  [self.sut onProcessingLog:log withPriority:MSPriorityDefault];
+
+  // Then
+  XCTAssertEqual(UINT64_MAX, log.toffset.unsignedLongLongValue);
+  XCTAssertEqual(log.sid, [self.sut.pastSessions lastObject].sessionId);
+};
+
 @end

--- a/MobileCenterAnalytics/MobileCenterAnalyticsTests/MSSessionTrackerTests.m
+++ b/MobileCenterAnalytics/MobileCenterAnalyticsTests/MSSessionTrackerTests.m
@@ -205,15 +205,15 @@ NSTimeInterval const kMSTestSessionTimeout = 1.5;
   XCTAssertNil(log.sid);
   XCTAssertNil(log.toffset);
 
+  // When
   [self.sut onProcessingLog:log withPriority:MSPriorityDefault];
 
-  // And then
+  // Then
   XCTAssertNil(log.toffset);
   XCTAssertEqual(log.sid, self.sut.sessionId);
 
   // When
   log.toffset = 0;
-
   [self.sut onProcessingLog:log withPriority:MSPriorityDefault];
 
   // Then
@@ -222,7 +222,6 @@ NSTimeInterval const kMSTestSessionTimeout = 1.5;
 
   // When
   log.toffset = [NSNumber numberWithUnsignedLongLong:UINT64_MAX];
-
   [self.sut onProcessingLog:log withPriority:MSPriorityDefault];
 
   // Then


### PR DESCRIPTION
Use a binary sort to search for the correct sessionID based on toffset.