### PR TITLE
Add error message

### DIFF
--- a/MobileCenterDistribute/MobileCenterDistribute/MSDistributeUtil.m
+++ b/MobileCenterDistribute/MobileCenterDistribute/MSDistributeUtil.m
@@ -1,6 +1,7 @@
 #import "MSDistribute.h"
 #import "MSDistributeInternal.h"
 #import "MSDistributeUtil.h"
+#import "MSLogger.h"
 
 NSBundle *MSDistributeBundle(void) {
   static NSBundle *bundle = nil;
@@ -11,6 +12,12 @@ NSBundle *MSDistributeBundle(void) {
     NSString *mainBundlePath = [[NSBundle bundleForClass:[MSDistribute class]] resourcePath];
     NSString *frameworkBundlePath = [mainBundlePath stringByAppendingPathComponent:MOBILE_CENTER_DISTRIBUTE_BUNDLE];
     bundle = [NSBundle bundleWithPath:frameworkBundlePath];
+    
+    // Log to console in case the bundle is nil.
+    if(!bundle) {
+      MSLogWarning([MSDistribute logTag], @"The MobileCenterDistributeResources.bundle file could not be found in your"
+              " app. Please it to your project as described in our readme.");
+    }
   });
   return bundle;
 }

--- a/MobileCenterDistribute/MobileCenterDistribute/MSDistributeUtil.m
+++ b/MobileCenterDistribute/MobileCenterDistribute/MSDistributeUtil.m
@@ -15,8 +15,8 @@ NSBundle *MSDistributeBundle(void) {
     
     // Log to console in case the bundle is nil.
     if(!bundle) {
-      MSLogWarning([MSDistribute logTag], @"The MobileCenterDistributeResources.bundle file could not be found in your"
-              " app. Please it to your project as described in our readme.");
+      MSLogError([MSDistribute logTag], @"The MobileCenterDistributeResources.bundle file could not be found in your"
+              " app. Please add it to your project as described in our readme.");
     }
   });
   return bundle;


### PR DESCRIPTION
We want to make sure that our SDK was integrated correctly, including the resource bundle for Distribute.
Compile-time checks for resources don't exist so the alternative would be assertions (checks at runtime). I don't like the idea of our SDK causing any crashes, not even when running in debug config or with a debugger attached, so my proposal is to log something.