### PR TITLE
Exclude PLCrashReporter, OCMock and OCHamcrest from additional warnings

### DIFF
--- a/MobileCenter/MobileCenter.xcodeproj/project.pbxproj
+++ b/MobileCenter/MobileCenter.xcodeproj/project.pbxproj
@@ -1016,11 +1016,19 @@
 				APPLICATION_EXTENSION_API_ONLY = NO;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				FRAMEWORK_SEARCH_PATHS = "\"$(SRCROOT)/../Vendor\"/**";
-				HEADER_SEARCH_PATHS = "\"$(SRCROOT)/../Vendor\"/**";
 				INFOPLIST_FILE = MobileCenterTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = "\"$(SRCROOT)/../Vendor\"/**";
+				OTHER_CFLAGS = (
+					"$(inherited)",
+					"-iframework",
+					"\"$(SRCROOT)/../Vendor/OCHamcrest\"",
+					"-iframework",
+					"\"$(SRCROOT)/../Vendor/OHHTTPStubs\"",
+					"-isystem",
+					"\"$(SRCROOT)/../Vendor/OCMock\"",
+				);
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-framework",
@@ -1038,11 +1046,19 @@
 				APPLICATION_EXTENSION_API_ONLY = NO;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				FRAMEWORK_SEARCH_PATHS = "\"$(SRCROOT)/../Vendor\"/**";
-				HEADER_SEARCH_PATHS = "\"$(SRCROOT)/../Vendor\"/**";
 				INFOPLIST_FILE = MobileCenterTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = "\"$(SRCROOT)/../Vendor\"/**";
+				OTHER_CFLAGS = (
+					"$(inherited)",
+					"-iframework",
+					"\"$(SRCROOT)/../Vendor/OCHamcrest\"",
+					"-iframework",
+					"\"$(SRCROOT)/../Vendor/OHHTTPStubs\"",
+					"-isystem",
+					"\"$(SRCROOT)/../Vendor/OCMock\"",
+				);
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-framework",

--- a/MobileCenter/MobileCenter.xcodeproj/project.pbxproj
+++ b/MobileCenter/MobileCenter.xcodeproj/project.pbxproj
@@ -298,6 +298,7 @@
 		E8A8D1EA1D3057A90022931E /* MSUserDefaults.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = MSUserDefaults.m; path = ../Model/Utils/MSUserDefaults.m; sourceTree = "<group>"; };
 		E8AEE9811D5970A400C0FF6C /* MSLogManagerDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MSLogManagerDelegate.h; sourceTree = "<group>"; };
 		E8E48F941D50FF4300A8C1B0 /* MSSenderCallDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MSSenderCallDelegate.h; sourceTree = "<group>"; };
+		F87A05571E72BD7C0038A6F9 /* Tests.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Tests.xcconfig; path = ../../../Tests.xcconfig; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -422,6 +423,7 @@
 				386E970B1E0371D2000D37FE /* Global.xcconfig */,
 				6E0401841D1CAD810051BCFA /* MobileCenter.xcconfig */,
 				6E0401851D1CAD810051BCFA /* module.modulemap */,
+				F87A05571E72BD7C0038A6F9 /* Tests.xcconfig */,
 			);
 			path = Support;
 			sourceTree = "<group>";
@@ -1012,29 +1014,16 @@
 		};
 		6E2395811D22EF4F00E543C8 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = F87A05571E72BD7C0038A6F9 /* Tests.xcconfig */;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = NO;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				FRAMEWORK_SEARCH_PATHS = "\"$(SRCROOT)/../Vendor\"/**";
+				HEADER_SEARCH_PATHS = "\"$(SRCROOT)/../Vendor\"/**";
 				INFOPLIST_FILE = MobileCenterTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = "\"$(SRCROOT)/../Vendor\"/**";
-				OTHER_CFLAGS = (
-					"$(inherited)",
-					"-iframework",
-					"\"$(SRCROOT)/../Vendor/OCHamcrest\"",
-					"-iframework",
-					"\"$(SRCROOT)/../Vendor/OHHTTPStubs\"",
-					"-isystem",
-					"\"$(SRCROOT)/../Vendor/OCMock\"",
-				);
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					"-framework",
-					Foundation,
-					"-ObjC",
-				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.azure.mobile.mobilecentertests;
 				PRODUCT_NAME = MobileCenter;
 			};
@@ -1042,29 +1031,16 @@
 		};
 		6E2395821D22EF4F00E543C8 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = F87A05571E72BD7C0038A6F9 /* Tests.xcconfig */;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = NO;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				FRAMEWORK_SEARCH_PATHS = "\"$(SRCROOT)/../Vendor\"/**";
+				HEADER_SEARCH_PATHS = "\"$(SRCROOT)/../Vendor\"/**";
 				INFOPLIST_FILE = MobileCenterTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = "\"$(SRCROOT)/../Vendor\"/**";
-				OTHER_CFLAGS = (
-					"$(inherited)",
-					"-iframework",
-					"\"$(SRCROOT)/../Vendor/OCHamcrest\"",
-					"-iframework",
-					"\"$(SRCROOT)/../Vendor/OHHTTPStubs\"",
-					"-isystem",
-					"\"$(SRCROOT)/../Vendor/OCMock\"",
-				);
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					"-framework",
-					Foundation,
-					"-ObjC",
-				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.azure.mobile.mobilecentertests;
 				PRODUCT_NAME = MobileCenter;
 			};

--- a/MobileCenter/MobileCenter/Support/MobileCenter.xcconfig
+++ b/MobileCenter/MobileCenter/Support/MobileCenter.xcconfig
@@ -1,3 +1,3 @@
 #include "../../../Global.xcconfig"
 
-OTHER_LDFLAGS=$(inherited)  -framework Foundation -framework SystemConfiguration -framework UIKit
+OTHER_LDFLAGS = $(inherited) -framework Foundation -framework SystemConfiguration -framework UIKit;

--- a/MobileCenter/MobileCenterTests/MSIngestionSenderTests.m
+++ b/MobileCenter/MobileCenterTests/MSIngestionSenderTests.m
@@ -13,8 +13,8 @@
 #import "MSSenderDelegate.h"
 #import "MobileCenter+Internal.h"
 
-#import "OCMock.h"
 #import <OCHamcrestIOS/OCHamcrestIOS.h>
+#import <OCMock/OCMock.h>
 #import <XCTest/XCTest.h>
 
 static NSTimeInterval const kMSTestTimeout = 5.0;

--- a/MobileCenterAnalytics/MobileCenterAnalytics.xcodeproj/project.pbxproj
+++ b/MobileCenterAnalytics/MobileCenterAnalytics.xcodeproj/project.pbxproj
@@ -623,7 +623,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				"ARCHS[sdk=iphonesimulator*]" = "$(MS_SIM_ARCHS)";
-				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				OTHER_LDFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = /usr/local/include;
 				PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.azure.mobile.mobilecenteranalytics;
@@ -639,7 +638,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				"ARCHS[sdk=iphonesimulator*]" = "$(MS_SIM_ARCHS)";
-				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				OTHER_LDFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = /usr/local/include;
 				PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.azure.mobile.mobilecenteranalytics;
@@ -657,11 +655,19 @@
 				APPLICATION_EXTENSION_API_ONLY = NO;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				FRAMEWORK_SEARCH_PATHS = "\"$(SRCROOT)/../Vendor\"/**";
-				HEADER_SEARCH_PATHS = "\"$(SRCROOT)/../Vendor\"/**";
 				INFOPLIST_FILE = MobileCenterAnalyticsTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = "\"$(SRCROOT)/../Vendor\"/**";
+				OTHER_CFLAGS = (
+					"$(inherited)",
+					"-iframework",
+					"\"$(SRCROOT)/../Vendor/OCHamcrest\"",
+					"-iframework",
+					"\"$(SRCROOT)/../Vendor/OHHTTPStubs\"",
+					"-isystem",
+					"\"$(SRCROOT)/../Vendor/OCMock\"",
+				);
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-framework",
@@ -680,11 +686,19 @@
 				APPLICATION_EXTENSION_API_ONLY = NO;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				FRAMEWORK_SEARCH_PATHS = "\"$(SRCROOT)/../Vendor\"/**";
-				HEADER_SEARCH_PATHS = "\"$(SRCROOT)/../Vendor\"/**";
 				INFOPLIST_FILE = MobileCenterAnalyticsTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = "\"$(SRCROOT)/../Vendor\"/**";
+				OTHER_CFLAGS = (
+					"$(inherited)",
+					"-iframework",
+					"\"$(SRCROOT)/../Vendor/OCHamcrest\"",
+					"-iframework",
+					"\"$(SRCROOT)/../Vendor/OHHTTPStubs\"",
+					"-isystem",
+					"\"$(SRCROOT)/../Vendor/OCMock\"",
+				);
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-framework",

--- a/MobileCenterAnalytics/MobileCenterAnalytics.xcodeproj/project.pbxproj
+++ b/MobileCenterAnalytics/MobileCenterAnalytics.xcodeproj/project.pbxproj
@@ -149,6 +149,7 @@
 		E8E48F9D1D515C3900A8C1B0 /* MSSessionTracker.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; lineEnding = 0; path = MSSessionTracker.m; sourceTree = "<group>"; xcLanguageSpecificationIdentifier = xcode.lang.objc; };
 		E8E48FA01D51670100A8C1B0 /* MSStartSessionLog.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MSStartSessionLog.h; sourceTree = "<group>"; };
 		E8E48FA11D51670100A8C1B0 /* MSStartSessionLog.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSStartSessionLog.m; sourceTree = "<group>"; };
+		F87A05581E72BDFC0038A6F9 /* Tests.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Tests.xcconfig; path = ../../../Tests.xcconfig; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -304,6 +305,7 @@
 				3856B47C1E032E7B0016AB05 /* Global.xcconfig */,
 				B2812EF21DA3148000307DCE /* MobileCenterAnalytics.xcconfig */,
 				B2812EF01DA3148000307DCE /* module.modulemap */,
+				F87A05581E72BDFC0038A6F9 /* Tests.xcconfig */,
 			);
 			path = Support;
 			sourceTree = "<group>";
@@ -651,29 +653,16 @@
 		};
 		E85547DE1D2D6723002DF6E2 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = F87A05581E72BDFC0038A6F9 /* Tests.xcconfig */;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = NO;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				FRAMEWORK_SEARCH_PATHS = "\"$(SRCROOT)/../Vendor\"/**";
+				HEADER_SEARCH_PATHS = "\"$(SRCROOT)/../Vendor\"/**";
 				INFOPLIST_FILE = MobileCenterAnalyticsTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = "\"$(SRCROOT)/../Vendor\"/**";
-				OTHER_CFLAGS = (
-					"$(inherited)",
-					"-iframework",
-					"\"$(SRCROOT)/../Vendor/OCHamcrest\"",
-					"-iframework",
-					"\"$(SRCROOT)/../Vendor/OHHTTPStubs\"",
-					"-isystem",
-					"\"$(SRCROOT)/../Vendor/OCMock\"",
-				);
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					"-framework",
-					Foundation,
-					"-ObjC",
-				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.azure.mobile.mobilecenteranalyticstests;
 				PRODUCT_NAME = MobileCenterAnalytics;
 				USER_HEADER_SEARCH_PATHS = "\"$(SRCROOT)/../MobileCenter/MobileCenter\"/**";
@@ -682,29 +671,16 @@
 		};
 		E85547DF1D2D6723002DF6E2 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = F87A05581E72BDFC0038A6F9 /* Tests.xcconfig */;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = NO;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				FRAMEWORK_SEARCH_PATHS = "\"$(SRCROOT)/../Vendor\"/**";
+				HEADER_SEARCH_PATHS = "\"$(SRCROOT)/../Vendor\"/**";
 				INFOPLIST_FILE = MobileCenterAnalyticsTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = "\"$(SRCROOT)/../Vendor\"/**";
-				OTHER_CFLAGS = (
-					"$(inherited)",
-					"-iframework",
-					"\"$(SRCROOT)/../Vendor/OCHamcrest\"",
-					"-iframework",
-					"\"$(SRCROOT)/../Vendor/OHHTTPStubs\"",
-					"-isystem",
-					"\"$(SRCROOT)/../Vendor/OCMock\"",
-				);
-				OTHER_LDFLAGS = (
-					"$(inherited)",
-					"-framework",
-					Foundation,
-					"-ObjC",
-				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.azure.mobile.mobilecenteranalyticstests;
 				PRODUCT_NAME = MobileCenterAnalytics;
 				USER_HEADER_SEARCH_PATHS = "\"$(SRCROOT)/../MobileCenter/MobileCenter\"/**";

--- a/MobileCenterAnalytics/MobileCenterAnalytics/Support/MobileCenterAnalytics.xcconfig
+++ b/MobileCenterAnalytics/MobileCenterAnalytics/Support/MobileCenterAnalytics.xcconfig
@@ -1,3 +1,3 @@
 #include "../../../Global.xcconfig"
 
-OTHER_LDFLAGS=$(inherited) -framework Foundation -framework UIKit -framework CoreTelephony
+OTHER_LDFLAGS = $(inherited) -framework Foundation -framework UIKit -framework CoreTelephony;

--- a/MobileCenterCrashes/MobileCenterCrashes.xcodeproj/project.pbxproj
+++ b/MobileCenterCrashes/MobileCenterCrashes.xcodeproj/project.pbxproj
@@ -859,9 +859,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				"ARCHS[sdk=iphonesimulator*]" = "$(MS_SIM_ARCHS)";
-				FRAMEWORK_SEARCH_PATHS = (
+				OTHER_CFLAGS = (
 					"$(inherited)",
-					"\"$(SRCROOT)/../Vendor\"/**",
+					"-iframework",
+					"\"$(SRCROOT)/../Vendor/PLCrashReporter\"",
 				);
 				OTHER_LDFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = /usr/local/include;
@@ -878,9 +879,10 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				"ARCHS[sdk=iphonesimulator*]" = "$(MS_SIM_ARCHS)";
-				FRAMEWORK_SEARCH_PATHS = (
+				OTHER_CFLAGS = (
 					"$(inherited)",
-					"\"$(SRCROOT)/../Vendor\"/**",
+					"-iframework",
+					"\"$(SRCROOT)/../Vendor/PLCrashReporter\"",
 				);
 				OTHER_LDFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = /usr/local/include;
@@ -899,11 +901,21 @@
 				APPLICATION_EXTENSION_API_ONLY = NO;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				FRAMEWORK_SEARCH_PATHS = "\"$(SRCROOT)/../Vendor\"/**";
-				HEADER_SEARCH_PATHS = "\"$(SRCROOT)/../Vendor\"/**";
 				INFOPLIST_FILE = MobileCenterCrashesTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = "\"$(SRCROOT)/../Vendor\"/**";
+				OTHER_CFLAGS = (
+					"$(inherited)",
+					"-iframework",
+					"\"$(SRCROOT)/../Vendor/PLCrashReporter\"",
+					"-iframework",
+					"\"$(SRCROOT)/../Vendor/OCHamcrest\"",
+					"-iframework",
+					"\"$(SRCROOT)/../Vendor/OHHTTPStubs\"",
+					"-isystem",
+					"\"$(SRCROOT)/../Vendor/OCMock\"",
+				);
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-framework",
@@ -922,11 +934,19 @@
 				APPLICATION_EXTENSION_API_ONLY = NO;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				FRAMEWORK_SEARCH_PATHS = "\"$(SRCROOT)/../Vendor\"/**";
-				HEADER_SEARCH_PATHS = "\"$(SRCROOT)/../Vendor\"/**";
 				INFOPLIST_FILE = MobileCenterCrashesTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = "\"$(SRCROOT)/../Vendor\"/**";
+				OTHER_CFLAGS = (
+					"$(inherited)",
+					"-iframework",
+					"\"$(SRCROOT)/../Vendor/OCHamcrest\"",
+					"-iframework",
+					"\"$(SRCROOT)/../Vendor/OHHTTPStubs\"",
+					"-isystem",
+					"\"$(SRCROOT)/../Vendor/OCMock\"",
+				);
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-framework",

--- a/MobileCenterCrashes/MobileCenterCrashes.xcodeproj/project.pbxproj
+++ b/MobileCenterCrashes/MobileCenterCrashes.xcodeproj/project.pbxproj
@@ -264,6 +264,7 @@
 		F859D1021E549B45008B2D8E /* live_report_swift_crash.plcrash */ = {isa = PBXFileReference; lastKnownFileType = file; path = live_report_swift_crash.plcrash; sourceTree = "<group>"; };
 		F859D1031E549B45008B2D8E /* live_report_undefined_instr.plcrash */ = {isa = PBXFileReference; lastKnownFileType = file; path = live_report_undefined_instr.plcrash; sourceTree = "<group>"; };
 		F859D1041E549B45008B2D8E /* live_report_write_readonly.plcrash */ = {isa = PBXFileReference; lastKnownFileType = file; path = live_report_write_readonly.plcrash; sourceTree = "<group>"; };
+		F87A05591E72BE420038A6F9 /* Tests.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; name = Tests.xcconfig; path = ../../../Tests.xcconfig; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -422,6 +423,7 @@
 				3856B47D1E032EC50016AB05 /* Global.xcconfig */,
 				6E37297F1D1DE93800F1E4AE /* MobileCenterCrashes.xcconfig */,
 				6E3729811D1DE93800F1E4AE /* module.modulemap */,
+				F87A05591E72BE420038A6F9 /* Tests.xcconfig */,
 			);
 			path = Support;
 			sourceTree = "<group>";
@@ -859,11 +861,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				"ARCHS[sdk=iphonesimulator*]" = "$(MS_SIM_ARCHS)";
-				OTHER_CFLAGS = (
-					"$(inherited)",
-					"-iframework",
-					"\"$(SRCROOT)/../Vendor/PLCrashReporter\"",
-				);
 				OTHER_LDFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = /usr/local/include;
 				PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.azure.mobile.mobilecentercrashes;
@@ -879,11 +876,6 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				"ARCHS[sdk=iphonesimulator*]" = "$(MS_SIM_ARCHS)";
-				OTHER_CFLAGS = (
-					"$(inherited)",
-					"-iframework",
-					"\"$(SRCROOT)/../Vendor/PLCrashReporter\"",
-				);
 				OTHER_LDFLAGS = "";
 				PRIVATE_HEADERS_FOLDER_PATH = /usr/local/include;
 				PRODUCT_BUNDLE_IDENTIFIER = com.microsoft.azure.mobile.mobilecentercrashes;
@@ -897,25 +889,16 @@
 		};
 		6E171AEA1D22F781000DC480 /* Debug */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = F87A05591E72BE420038A6F9 /* Tests.xcconfig */;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = NO;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				FRAMEWORK_SEARCH_PATHS = "\"$(SRCROOT)/../Vendor\"/**";
+				HEADER_SEARCH_PATHS = "\"$(SRCROOT)/../Vendor\"/**";
 				INFOPLIST_FILE = MobileCenterCrashesTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = "\"$(SRCROOT)/../Vendor\"/**";
-				OTHER_CFLAGS = (
-					"$(inherited)",
-					"-iframework",
-					"\"$(SRCROOT)/../Vendor/PLCrashReporter\"",
-					"-iframework",
-					"\"$(SRCROOT)/../Vendor/OCHamcrest\"",
-					"-iframework",
-					"\"$(SRCROOT)/../Vendor/OHHTTPStubs\"",
-					"-isystem",
-					"\"$(SRCROOT)/../Vendor/OCMock\"",
-				);
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-framework",
@@ -930,23 +913,16 @@
 		};
 		6E171AEB1D22F781000DC480 /* Release */ = {
 			isa = XCBuildConfiguration;
+			baseConfigurationReference = F87A05591E72BE420038A6F9 /* Tests.xcconfig */;
 			buildSettings = {
 				APPLICATION_EXTENSION_API_ONLY = NO;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				FRAMEWORK_SEARCH_PATHS = "\"$(SRCROOT)/../Vendor\"/**";
+				HEADER_SEARCH_PATHS = "\"$(SRCROOT)/../Vendor\"/**";
 				INFOPLIST_FILE = MobileCenterCrashesTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				LIBRARY_SEARCH_PATHS = "\"$(SRCROOT)/../Vendor\"/**";
-				OTHER_CFLAGS = (
-					"$(inherited)",
-					"-iframework",
-					"\"$(SRCROOT)/../Vendor/OCHamcrest\"",
-					"-iframework",
-					"\"$(SRCROOT)/../Vendor/OHHTTPStubs\"",
-					"-isystem",
-					"\"$(SRCROOT)/../Vendor/OCMock\"",
-				);
 				OTHER_LDFLAGS = (
 					"$(inherited)",
 					"-framework",

--- a/MobileCenterCrashes/MobileCenterCrashes/Support/MobileCenterCrashes.xcconfig
+++ b/MobileCenterCrashes/MobileCenterCrashes/Support/MobileCenterCrashes.xcconfig
@@ -1,3 +1,4 @@
 #include "../../../Global.xcconfig"
 
-OTHER_LDFLAGS=$(inherited) -framework CrashReporter -framework Foundation -framework UIKit -lc++ -lz
+OTHER_CFLAGS = $(OTHER_CFLAGS) -iframework "$(SRCROOT)/../Vendor/PLCrashReporter";
+OTHER_LDFLAGS = $(inherited) -framework CrashReporter -framework Foundation -framework UIKit -lc++ -lz;

--- a/Tests.xcconfig
+++ b/Tests.xcconfig
@@ -1,0 +1,2 @@
+OTHER_CFLAGS = $(inherited) -isystem "$(SRCROOT)/../Vendor/OCMock" -iframework "$(SRCROOT)/../Vendor/OCHamcrest" -iframework "$(SRCROOT)/../Vendor/OHHTTPStubs";
+OTHER_LDFLAGS = $(inherited) -framework Foundation -ObjC;


### PR DESCRIPTION
For suppress warnings from headers in the 3rd party libraries, mark they as "system headers" for compiler.