### PR TITLE
Rearrange buttons on update dialog

### DIFF
--- a/MobileCenterDistribute/MobileCenterDistribute/MSDistribute.m
+++ b/MobileCenterDistribute/MobileCenterDistribute/MSDistribute.m
@@ -411,6 +411,12 @@ static NSString *const kMSUpdateTokenURLInvalidErrorDescFormat = @"Invalid updat
         [MSAlertController alertControllerWithTitle:MSDistributeLocalizedString(@"Update available")
                                             message:releaseNotes];
 
+    // Add a "Postpone"-Button
+    [alertController addDefaultActionWithTitle:MSDistributeLocalizedString(@"Postpone")
+                                       handler:^(UIAlertAction *action) {
+                                         MSLogDebug([MSDistribute logTag], @"Postpone the release for now.");
+                                       }];
+
     // Add a "Ignore"-Button
     [alertController addDefaultActionWithTitle:MSDistributeLocalizedString(@"Ignore")
                                        handler:^(UIAlertAction *action) {
@@ -418,18 +424,12 @@ static NSString *const kMSUpdateTokenURLInvalidErrorDescFormat = @"Invalid updat
                                          [MS_USER_DEFAULTS setObject:details.id forKey:kMSIgnoredReleaseIdKey];
                                        }];
 
-    // Add a "Postpone"-Button
-    [alertController addCancelActionWithTitle:MSDistributeLocalizedString(@"Postpone")
-                                      handler:^(UIAlertAction *action) {
-                                        MSLogDebug([MSDistribute logTag], @"Postpone the release for now.");
-                                      }];
-
     // Add a "Download"-Button
-    [alertController addDefaultActionWithTitle:MSDistributeLocalizedString(@"Download")
-                                       handler:^(UIAlertAction *action) {
-                                         MSLogDebug([MSDistribute logTag], @"Start download and install the release.");
-                                         [self startDownload:details];
-                                       }];
+    [alertController addCancelActionWithTitle:MSDistributeLocalizedString(@"Download")
+                                      handler:^(UIAlertAction *action) {
+                                        MSLogDebug([MSDistribute logTag], @"Start download and install the release.");
+                                        [self startDownload:details];
+                                      }];
 
     // Show the alert controller.
     MSLogDebug([MSDistribute logTag], @"Show update dialog.");

--- a/MobileCenterDistribute/MobileCenterDistribute/MSDistribute.m
+++ b/MobileCenterDistribute/MobileCenterDistribute/MSDistribute.m
@@ -414,7 +414,7 @@ static NSString *const kMSUpdateTokenURLInvalidErrorDescFormat = @"Invalid updat
     // Add a "Postpone"-Button
     [alertController addDefaultActionWithTitle:MSDistributeLocalizedString(@"Postpone")
                                        handler:^(UIAlertAction *action) {
-                                         MSLogDebug([MSDistribute logTag], @"Postpone the release for now.");
+                                         MSLogDebug([MSDistribute logTag], @"Postpone the update for now.");
                                        }];
 
     // Add a "Ignore"-Button
@@ -427,7 +427,7 @@ static NSString *const kMSUpdateTokenURLInvalidErrorDescFormat = @"Invalid updat
     // Add a "Download"-Button
     [alertController addCancelActionWithTitle:MSDistributeLocalizedString(@"Download")
                                       handler:^(UIAlertAction *action) {
-                                        MSLogDebug([MSDistribute logTag], @"Start download and install the release.");
+                                        MSLogDebug([MSDistribute logTag], @"Start download and install the update.");
                                         [self startDownload:details];
                                       }];
 


### PR DESCRIPTION
Failed to have scrolling behavior on update dialog, this change is only for rearrange buttons.