### PR TITLE
Clean-up property attributes for core.

### DIFF
--- a/MobileCenter/MobileCenter/Internals/Channel/MSChannel.h
+++ b/MobileCenter/MobileCenter/Internals/Channel/MSChannel.h
@@ -21,7 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 /*
  * The configuration used by this channel.
  */
-@property(nonatomic, strong) MSChannelConfiguration *configuration;
+@property(nonatomic) MSChannelConfiguration *configuration;
 
 /**
  * Initializes a new `MSChannelDefault` instance.

--- a/MobileCenter/MobileCenter/Internals/Channel/MSChannelDefault.h
+++ b/MobileCenter/MobileCenter/Internals/Channel/MSChannelDefault.h
@@ -14,7 +14,7 @@ typedef void (^enqueueCompletionBlock)(BOOL);
 /**
  * Queue used to process logs.
  */
-@property(nonatomic, strong) dispatch_queue_t logsDispatchQueue;
+@property(nonatomic) dispatch_queue_t logsDispatchQueue;
 
 /**
  * Hash table of channel delegate.
@@ -24,18 +24,18 @@ typedef void (^enqueueCompletionBlock)(BOOL);
 /**
  * A sender instance that is used to send batches of log items to the backend.
  */
-@property(nonatomic, strong) id<MSSender> sender;
+@property(nonatomic) id<MSSender> sender;
 
 /**
  * A storage instance to store and read enqueued log items.
  */
-@property(nonatomic, strong) id<MSStorage> storage;
+@property(nonatomic) id<MSStorage> storage;
 
 /**
  * A timer source which is used to flush the queue after a certain amount of
  * time.
  */
-@property(nonatomic, strong) dispatch_source_t timerSource;
+@property(nonatomic) dispatch_source_t timerSource;
 
 /**
  * A counter that keeps tracks of the number of logs added to the queue.

--- a/MobileCenter/MobileCenter/Internals/Channel/MSLogManagerDefault.m
+++ b/MobileCenter/MobileCenter/Internals/Channel/MSLogManagerDefault.m
@@ -17,7 +17,7 @@ static char *const MSlogsDispatchQueue = "com.microsoft.azure.mobile.mobilecente
 /**
  * A boolean value set to YES if this instance is enabled or NO otherwise.
  */
-@property(atomic) BOOL enabled;
+@property BOOL enabled;
 
 @end
 

--- a/MobileCenter/MobileCenter/Internals/MSMobileCenterInternal.h
+++ b/MobileCenter/MobileCenter/Internals/MSMobileCenterInternal.h
@@ -17,8 +17,8 @@ static NSString *const kMSMobileCenterIsEnabledKey = @"MSMobileCenterIsEnabled";
 @property(nonatomic, copy) NSString *logUrl;
 @property(nonatomic, readonly) NSUUID *installId;
 @property(nonatomic, copy) NSString *apiVersion;
-@property(atomic) BOOL sdkConfigured;
-@property(atomic) BOOL enabledStateUpdating;
+@property BOOL sdkConfigured;
+@property BOOL enabledStateUpdating;
 
 /**
  * Returns the singleton instance of Mobile Center.

--- a/MobileCenter/MobileCenter/Internals/MSServiceAbstractInternal.h
+++ b/MobileCenter/MobileCenter/Internals/MSServiceAbstractInternal.h
@@ -15,7 +15,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Flag indicating if a service has been started or not.
  */
-@property(nonatomic, readwrite) BOOL started;
+@property(nonatomic) BOOL started;
 
 #pragma mark - Service initialization
 

--- a/MobileCenter/MobileCenter/Internals/MSServiceAbstractPrivate.h
+++ b/MobileCenter/MobileCenter/Internals/MSServiceAbstractPrivate.h
@@ -14,7 +14,7 @@
 /**
  *  Storage used for persistence.
  */
-@property(nonatomic, readwrite) MSUserDefaults *storage;
+@property(nonatomic) MSUserDefaults *storage;
 
 /**
  *  (For testing only) Create a service with the given storage.

--- a/MobileCenter/MobileCenter/Internals/Model/MSDevicePrivate.h
+++ b/MobileCenter/MobileCenter/Internals/Model/MSDevicePrivate.h
@@ -6,83 +6,83 @@
 /*
  * Name of the SDK. Consists of the name of the SDK and the platform, e.g. "mobilecenter.ios", "mobilecenter.android"
  */
-@property(nonatomic, copy, readwrite) NSString *sdkName;
+@property(nonatomic, copy) NSString *sdkName;
 
 /*
  * Version of the SDK in semver format, e.g. "1.2.0" or "0.12.3-alpha.1".
  */
-@property(nonatomic, copy, readwrite) NSString *sdkVersion;
+@property(nonatomic, copy) NSString *sdkVersion;
 
 /*
  * Device model (example: iPad2,3).
  */
-@property(nonatomic, copy, readwrite) NSString *model;
+@property(nonatomic, copy) NSString *model;
 
 /*
  * Device manufacturer (example: HTC).
  */
-@property(nonatomic, copy, readwrite) NSString *oemName;
+@property(nonatomic, copy) NSString *oemName;
 
 /*
  * OS name (example: iOS).
  */
-@property(nonatomic, copy, readwrite) NSString *osName;
+@property(nonatomic, copy) NSString *osName;
 
 /*
  * OS version (example: 9.3.0).
  */
-@property(nonatomic, copy, readwrite) NSString *osVersion;
+@property(nonatomic, copy) NSString *osVersion;
 
 /*
  * OS build code (example: LMY47X).  [optional]
  */
-@property(nonatomic, copy, readwrite) NSString *osBuild;
+@property(nonatomic, copy) NSString *osBuild;
 
 /*
  * API level when applicable like in Android (example: 15).  [optional]
  */
-@property(nonatomic, readwrite) NSNumber *osApiLevel;
+@property(nonatomic) NSNumber *osApiLevel;
 
 /*
  * Language code (example: en_US).
  */
-@property(nonatomic, copy, readwrite) NSString *locale;
+@property(nonatomic, copy) NSString *locale;
 
 /*
  * The offset in minutes from UTC for the device time zone, including daylight savings time.
  */
-@property(nonatomic, readwrite) NSNumber *timeZoneOffset;
+@property(nonatomic) NSNumber *timeZoneOffset;
 
 /*
  * Screen size of the device in pixels (example: 640x480).
  */
-@property(nonatomic, copy, readwrite) NSString *screenSize;
+@property(nonatomic, copy) NSString *screenSize;
 
 /*
  * Application version name, e.g. 1.1.0
  */
-@property(nonatomic, copy, readwrite) NSString *appVersion;
+@property(nonatomic, copy) NSString *appVersion;
 
 /*
  * Carrier name (for mobile devices).  [optional]
  */
-@property(nonatomic, copy, readwrite) NSString *carrierName;
+@property(nonatomic, copy) NSString *carrierName;
 
 /*
  * Carrier country code (for mobile devices).  [optional]
  */
-@property(nonatomic, copy, readwrite) NSString *carrierCountry;
+@property(nonatomic, copy) NSString *carrierCountry;
 
 /*
  * The app's build number, e.g. 42.
  */
-@property(nonatomic, copy, readwrite) NSString *appBuild;
+@property(nonatomic, copy) NSString *appBuild;
 
 /*
  * The bundle identifier, package identifier, or namespace, depending on what the individual plattforms use,  .e.g
  * com.microsoft.example.  [optional]
  */
-@property(nonatomic, copy, readwrite) NSString *appNamespace;
+@property(nonatomic, copy) NSString *appNamespace;
 
 
 @end

--- a/MobileCenter/MobileCenter/Internals/Model/MSWrapperSdkPrivate.h
+++ b/MobileCenter/MobileCenter/Internals/Model/MSWrapperSdkPrivate.h
@@ -8,27 +8,27 @@
  * the Xamarin specific version is populated into this field while sdkVersion refers to the original Android SDK.
  * [optional]
  */
-@property(nonatomic, copy, readwrite) NSString *wrapperSdkVersion;
+@property(nonatomic, copy) NSString *wrapperSdkVersion;
 
 /*
  * Name of the wrapper SDK (examples: Xamarin, Cordova).  [optional]
  */
-@property(nonatomic,copy, readwrite) NSString *wrapperSdkName;
+@property(nonatomic,copy) NSString *wrapperSdkName;
 
 /*
  * Label that is used to identify application code 'version' released via Live Update beacon running on device
  */
-@property(nonatomic, copy, readwrite) NSString *liveUpdateReleaseLabel;
+@property(nonatomic, copy) NSString *liveUpdateReleaseLabel;
 
 /*
  * Identifier of environment that current application release belongs to, deployment key then maps to environment like Production, Staging.
  */
-@property(nonatomic, copy, readwrite) NSString *liveUpdateDeploymentKey;
+@property(nonatomic, copy) NSString *liveUpdateDeploymentKey;
 
 /*
  * Hash of all files (ReactNative or Cordova) deployed to device via LiveUpdate beacon.
  * Helps identify the Release version on device or need to download updates in future
  */
-@property(nonatomic, copy, readwrite) NSString *liveUpdatePackageHash;
+@property(nonatomic, copy) NSString *liveUpdatePackageHash;
 
 @end

--- a/MobileCenter/MobileCenter/Internals/Sender/MSHttpSender.h
+++ b/MobileCenter/MobileCenter/Internals/Sender/MSHttpSender.h
@@ -8,27 +8,27 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Base URL (schema + authority + port only) used to communicate with the server.
  */
-@property(nonatomic) NSString *baseURL;
+@property(nonatomic, copy) NSString *baseURL;
 
 /**
  * API URL path used to identify an API from the server.
  */
-@property(nonatomic) NSString *apiPath;
+@property(nonatomic, copy) NSString *apiPath;
 
 /**
  *	Send Url.
  */
-@property(nonatomic, strong) NSURL *sendURL;
+@property(nonatomic) NSURL *sendURL;
 
 /**
  *	Request header parameters.
  */
-@property(nonatomic, strong) NSDictionary *httpHeaders;
+@property(nonatomic) NSDictionary *httpHeaders;
 
 /**
  *  Pending http calls.
  */
-@property(atomic, strong) NSMutableDictionary<NSString *, MSSenderCall *> *pendingCalls;
+@property NSMutableDictionary<NSString *, MSSenderCall *> *pendingCalls;
 
 /**
  *  Send data to backend

--- a/MobileCenter/MobileCenter/Internals/Sender/MSHttpSenderPrivate.h
+++ b/MobileCenter/MobileCenter/Internals/Sender/MSHttpSenderPrivate.h
@@ -8,17 +8,17 @@ static NSString *const kMSHidingStringForAppSecret = @"*";
 
 @interface MSHttpSender ()
 
-@property(nonatomic, strong) NSURLSession *session;
+@property(nonatomic) NSURLSession *session;
 
 /**
  * Retry intervals used by calls in case of recoverable errors.
  */
-@property(nonatomic, strong) NSArray *callsRetryIntervals;
+@property(nonatomic) NSArray *callsRetryIntervals;
 
 /**
  * Hash table containing all the delegates as weak references.
  */
-@property(atomic, strong) NSHashTable<id<MSSenderDelegate>> *delegates;
+@property NSHashTable<id<MSSenderDelegate>> *delegates;
 
 /**
  * A boolean value set to YES if the sender is enabled or NO otherwise.

--- a/MobileCenter/MobileCenter/Internals/Sender/MSSenderCall.h
+++ b/MobileCenter/MobileCenter/Internals/Sender/MSSenderCall.h
@@ -33,7 +33,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * A timer source which is used to flush the queue after a certain amount of time.
  */
-@property(nonatomic, strong) dispatch_source_t timerSource;
+@property(nonatomic) dispatch_source_t timerSource;
 
 /**
  * Number of retries performed for this call.

--- a/MobileCenter/MobileCenter/Internals/Storage/MSFile.h
+++ b/MobileCenter/MobileCenter/Internals/Storage/MSFile.h
@@ -10,7 +10,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * The creation date of the file.
  */
-@property(nonatomic, strong) NSDate *creationDate;
+@property(nonatomic) NSDate *creationDate;
 
 /**
  * The unique identifier for this file.

--- a/MobileCenter/MobileCenter/Internals/Storage/MSFileStorage.h
+++ b/MobileCenter/MobileCenter/Internals/Storage/MSFileStorage.h
@@ -14,7 +14,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * A dictionary containing file names and their status for certain storage keys.
  */
-@property(nonatomic, strong) NSMutableDictionary<NSString *, MSStorageBucket *> *buckets;
+@property(nonatomic) NSMutableDictionary<NSString *, MSStorageBucket *> *buckets;
 
 /**
  * Returns the file path to a log file based on its id and storage key.

--- a/MobileCenter/MobileCenter/Internals/Storage/MSFileUtil.m
+++ b/MobileCenter/MobileCenter/Internals/Storage/MSFileUtil.m
@@ -7,7 +7,7 @@
  */
 @interface MSFileUtil ()
 
-@property(nonatomic, strong) NSFileManager *fileManager;
+@property(nonatomic) NSFileManager *fileManager;
 
 @end
 

--- a/MobileCenter/MobileCenter/Internals/Storage/MSStorageBucket.h
+++ b/MobileCenter/MobileCenter/Internals/Storage/MSStorageBucket.h
@@ -12,22 +12,22 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * The file instance representing the current file used for adding new logs.
  */
-@property(nonatomic, strong) MSFile *currentFile;
+@property(nonatomic) MSFile *currentFile;
 
 /**
  * A in-memory list of all items that have been added to the current batch.
  */
-@property(nonatomic, strong) NSMutableArray<MSLog> *currentLogs;
+@property(nonatomic) NSMutableArray<MSLog> *currentLogs;
 
 /**
  * A list of file names that are currently used by other components.
  */
-@property(nonatomic, strong) NSMutableArray<MSFile *> *blockedFiles;
+@property(nonatomic) NSMutableArray<MSFile *> *blockedFiles;
 
 /**
  * A list of file names that can be accessed by other components.
  */
-@property(nonatomic, strong) NSMutableArray<MSFile *> *availableFiles;
+@property(nonatomic) NSMutableArray<MSFile *> *availableFiles;
 
 /**
  * Returns the file with the given id.

--- a/MobileCenter/MobileCenterTests/MSChannelDefaultTests.m
+++ b/MobileCenter/MobileCenterTests/MSChannelDefaultTests.m
@@ -14,22 +14,22 @@ static NSString *const kMSTestPriorityName = @"Prio";
 
 @interface MSChannelDefaultTests : XCTestCase
 
-@property(nonatomic, strong) MSChannelDefault *sut;
+@property(nonatomic) MSChannelDefault *sut;
 
-@property(nonatomic, strong) dispatch_queue_t logsDispatchQueue;
+@property(nonatomic) dispatch_queue_t logsDispatchQueue;
 
-@property(nonatomic, strong) MSChannelConfiguration *configMock;
+@property(nonatomic) MSChannelConfiguration *configMock;
 
-@property(nonatomic, strong) id<MSStorage> storageMock;
+@property(nonatomic) id<MSStorage> storageMock;
 
-@property(nonatomic, strong) id<MSSender> senderMock;
+@property(nonatomic) id<MSSender> senderMock;
 
 /**
  * Most of the channel APIs are asynchronous, this expectation is meant to be enqueued to the data dispatch queue
  * at the end of the test before any asserts. Then it will be triggered on the next queue loop right after the channel
  * finished its job. Wrap asserts within the handler of a waitForExpectationsWithTimeout method.
  */
-@property(nonatomic, strong) XCTestExpectation *channelEndJobExpectation;
+@property(nonatomic) XCTestExpectation *channelEndJobExpectation;
 
 @end
 

--- a/MobileCenter/MobileCenterTests/MSDeviceLogTests.m
+++ b/MobileCenter/MobileCenterTests/MSDeviceLogTests.m
@@ -9,7 +9,7 @@
 
 @interface MSDeviceTests : XCTestCase
 
-@property(nonatomic, strong) MSDevice *sut;
+@property(nonatomic) MSDevice *sut;
 
 @end
 

--- a/MobileCenter/MobileCenterTests/MSDeviceTrackerTests.m
+++ b/MobileCenter/MobileCenterTests/MSDeviceTrackerTests.m
@@ -14,7 +14,7 @@ static NSString *const kMSDeviceManufacturerTest = @"Apple";
 
 @interface MSDeviceTrackerTests : XCTestCase
 
-@property(nonatomic, strong) MSDeviceTracker *sut;
+@property(nonatomic) MSDeviceTracker *sut;
 
 @end
 

--- a/MobileCenter/MobileCenterTests/MSFileStorageTests.m
+++ b/MobileCenter/MobileCenterTests/MSFileStorageTests.m
@@ -11,7 +11,7 @@
 
 @interface MSFileStorageTests : XCTestCase
 
-@property(nonatomic, strong) MSFileStorage *sut;
+@property(nonatomic) MSFileStorage *sut;
 
 @end
 

--- a/MobileCenter/MobileCenterTests/MSFileTests.m
+++ b/MobileCenter/MobileCenterTests/MSFileTests.m
@@ -7,7 +7,7 @@
 
 @interface MSFileTests : XCTestCase
 
-@property(nonatomic, strong) MSFile *sut;
+@property(nonatomic) MSFile *sut;
 @end
 
 @implementation MSFileTests

--- a/MobileCenter/MobileCenterTests/MSIngestionSenderTests.m
+++ b/MobileCenter/MobileCenterTests/MSIngestionSenderTests.m
@@ -23,8 +23,8 @@ static NSString *const kMSAppSecret = @"mockAppSecret";
 
 @interface MSIngestionSenderTests : XCTestCase
 
-@property(nonatomic, strong) MSIngestionSender *sut;
-@property(nonatomic, strong) id reachabilityMock;
+@property(nonatomic) MSIngestionSender *sut;
+@property(nonatomic) id reachabilityMock;
 @property(nonatomic) NetworkStatus currentNetworkStatus;
 
 @end

--- a/MobileCenter/MobileCenterTests/MSLogWithPropertiesTests.m
+++ b/MobileCenter/MobileCenterTests/MSLogWithPropertiesTests.m
@@ -7,7 +7,7 @@
 
 @interface MSLogWithPropertiesTests : XCTestCase
 
-@property(nonatomic, strong) MSLogWithProperties *sut;
+@property(nonatomic) MSLogWithProperties *sut;
 
 @end
 

--- a/MobileCenter/MobileCenterTests/MSStorageBucketTests.m
+++ b/MobileCenter/MobileCenterTests/MSStorageBucketTests.m
@@ -7,7 +7,7 @@
 
 @interface MSStorageBucketTests : XCTestCase
 
-@property(nonatomic, strong) MSStorageBucket *sut;
+@property(nonatomic) MSStorageBucket *sut;
 
 @end
 

--- a/MobileCenterAnalytics/MobileCenterAnalyticsTests/MSEventLogTests.m
+++ b/MobileCenterAnalytics/MobileCenterAnalyticsTests/MSEventLogTests.m
@@ -8,7 +8,7 @@
 
 @interface MSEventLogTests : XCTestCase
 
-@property(nonatomic, strong) MSEventLog *sut;
+@property(nonatomic) MSEventLog *sut;
 
 @end
 

--- a/MobileCenterAnalytics/MobileCenterAnalyticsTests/MSPageLogTests.m
+++ b/MobileCenterAnalytics/MobileCenterAnalyticsTests/MSPageLogTests.m
@@ -7,7 +7,7 @@
 
 @interface MSPageLogTests : XCTestCase
 
-@property(nonatomic, strong) MSPageLog *sut;
+@property(nonatomic) MSPageLog *sut;
 
 @end
 

--- a/MobileCenterAnalytics/MobileCenterAnalyticsTests/MSStartSessionLogTests.m
+++ b/MobileCenterAnalytics/MobileCenterAnalyticsTests/MSStartSessionLogTests.m
@@ -7,7 +7,7 @@
 
 @interface MSStartSessionLogTests : XCTestCase
 
-@property(nonatomic, strong) MSStartSessionLog *sut;
+@property(nonatomic) MSStartSessionLog *sut;
 
 @end
 


### PR DESCRIPTION
I actually found two properties of type NSString that were missing the `copy` attribute.