### PR TITLE
Clean-up property attributes for Distribute

### DIFF
--- a/MobileCenterDistribute/MobileCenterDistribute/Internals/Model/MSReleaseDetails.h
+++ b/MobileCenterDistribute/MobileCenterDistribute/Internals/Model/MSReleaseDetails.h
@@ -55,7 +55,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * The release's size in bytes.
  */
-@property(nonatomic, copy) NSNumber *size;
+@property(nonatomic) NSNumber *size;
 
 /**
  * The release's minimum required operating system.
@@ -70,33 +70,33 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * UTC time in ISO 8601 format of the uploaded time.
  */
-@property(nonatomic, copy) NSDate *uploadedAt;
+@property(nonatomic) NSDate *uploadedAt;
 
 /**
  * The URL that hosts the binary for this release.
  */
-@property(nonatomic, copy) NSURL *downloadUrl;
+@property(nonatomic) NSURL *downloadUrl;
 
 /**
  * A URL to the app's icon.
  */
-@property(nonatomic, copy) NSURL *appIconUrl;
+@property(nonatomic) NSURL *appIconUrl;
 
 /**
  * The href required to install a release on a mobile device.
  * On iOS devices will be prefixed with 'itms-services://?action=download-manifest&url='
  */
-@property(nonatomic, copy) NSURL *installUrl;
+@property(nonatomic) NSURL *installUrl;
 
 /**
  * A list of distribution groups that are associated with this release.
  */
-@property(nonatomic, copy) NSArray<MSDistributionGroup *> *distributionGroups;
+@property(nonatomic) NSArray<MSDistributionGroup *> *distributionGroups;
 
 /**
  * A list of package hashes associated with this release. There is one hash (UUID) per architecture.
  */
-@property(nonatomic, copy) NSArray<NSString *> *packageHashes;
+@property(nonatomic) NSArray<NSString *> *packageHashes;
 
 /**
  * Initialize an object from dictionary.

--- a/MobileCenterDistribute/MobileCenterDistribute/MSBasicMachOParser.h
+++ b/MobileCenterDistribute/MobileCenterDistribute/MSBasicMachOParser.h
@@ -8,7 +8,7 @@
 /**
  * UUID parsed out of the current file.
  */
-@property(nonatomic, strong) NSUUID *uuid;
+@property(nonatomic) NSUUID *uuid;
 
 /**
  * Initialize a Mach-O parser for the given bundle

--- a/MobileCenterDistribute/MobileCenterDistribute/MSBasicMachOParser.m
+++ b/MobileCenterDistribute/MobileCenterDistribute/MSBasicMachOParser.m
@@ -13,7 +13,7 @@ static NSString *const kMSCantReadErrorDescFormat = @"Cannot read data from file
 
 @interface MSBasicMachOParser ()
 
-@property(nonatomic, strong) NSURL *fileURL;
+@property(nonatomic) NSURL *fileURL;
 
 @end
 

--- a/MobileCenterDistribute/MobileCenterDistributeTests/MSDistributeTests.m
+++ b/MobileCenterDistribute/MobileCenterDistributeTests/MSDistributeTests.m
@@ -51,8 +51,8 @@ static NSURL *sfURL;
 
 @interface MSDistributeTests : XCTestCase
 
-@property(nonatomic, strong) MSDistribute *sut;
-@property(nonatomic, strong) id parserMock;
+@property(nonatomic) MSDistribute *sut;
+@property(nonatomic) id parserMock;
 
 @end
 


### PR DESCRIPTION
One thing about this:
I noticed that `MSReleaseDetails` used `copy` for all of it's properties. I've changed that but maybe I'm missing something here and there was a reason for it?