### PR TITLE
Exclude XCTest.framework from warnings

### DIFF
--- a/Tests.xcconfig
+++ b/Tests.xcconfig
@@ -1,2 +1,2 @@
-OTHER_CFLAGS = $(inherited) -isystem "$(SRCROOT)/../Vendor/OCMock" -iframework "$(SRCROOT)/../Vendor/OCHamcrest" -iframework "$(SRCROOT)/../Vendor/OHHTTPStubs";
+OTHER_CFLAGS = $(inherited) -isystem "$(SRCROOT)/../Vendor/OCMock" -iframework "$(SRCROOT)/../Vendor/OCHamcrest" -iframework "$(SRCROOT)/../Vendor/OHHTTPStubs" -iframework "$(PLATFORM_DIR)/Developer/Library/Frameworks";
 OTHER_LDFLAGS = $(inherited) -framework Foundation -ObjC;


### PR DESCRIPTION
Remove useless warnings related to the `XCTest.framework`.
No need specific changes to apply to projects in other branches.