### PR TITLE
Fixed use of old style cast warnings

### DIFF
--- a/MobileCenterCrashes/MobileCenterCrashes/MSCrashes.mm
+++ b/MobileCenterCrashes/MobileCenterCrashes/MSCrashes.mm
@@ -141,7 +141,8 @@ static void uncaught_cxx_exception_handler(const MSCrashesUncaughtCXXExceptionIn
 + (void)setUserConfirmationHandler:(_Nullable MSUserConfirmationHandler)userConfirmationHandler {
 
   // FIXME: Type cast is required at the moment. Need to fix the root cause.
-  ((MSCrashes *)[self sharedInstance]).userConfirmationHandler = userConfirmationHandler;
+  MSCrashes * crashes = static_cast<MSCrashes *>([self sharedInstance]);
+  crashes.userConfirmationHandler = userConfirmationHandler;
 }
 
 + (void)notifyWithUserConfirmation:(MSUserConfirmation)userConfirmation {
@@ -344,7 +345,8 @@ static void uncaught_cxx_exception_handler(const MSCrashesUncaughtCXXExceptionIn
 - (void)onEnqueuingLog:(id<MSLog>)log withInternalId:(NSString *)internalId andPriority:(MSPriority)priority {
 
   // Don't buffer event if log is empty, crashes module is disabled or the log is a crash.
-  if (!log || ![self isEnabled] || [((NSObject *)log) isKindOfClass:[MSAppleErrorLog class]]) {
+  NSObject *logObject = static_cast<NSObject *>(log);
+  if (!log || ![self isEnabled] || [logObject isKindOfClass:[MSAppleErrorLog class]]) {
     return;
   }
 
@@ -377,9 +379,8 @@ static void uncaught_cxx_exception_handler(const MSCrashesUncaughtCXXExceptionIn
            * The current element is full. Save the timestamp if applicable and continue iterating unless we have
            * reached the last element.
            */
-          NSNumber *bufferedLogTimestamp = [timestampFormatter
-              numberFromString:((NSString * _Nonnull)
-                                    [NSString stringWithCString:it->timestamp.c_str() encoding:NSUTF8StringEncoding])];
+          NSString * timestamp = [NSString stringWithCString:it->timestamp.c_str() encoding:NSUTF8StringEncoding];
+          NSNumber *bufferedLogTimestamp = [timestampFormatter numberFromString:timestamp];
 
           // Remember the timestamp if the log is older than the previous one or the initial one.
           if (!oldestTimestamp || oldestTimestamp.doubleValue > bufferedLogTimestamp.doubleValue) {
@@ -441,8 +442,10 @@ static void uncaught_cxx_exception_handler(const MSCrashesUncaughtCXXExceptionIn
 
 - (void)channel:(id)channel willSendLog:(id<MSLog>)log {
   if (self.delegate && [self.delegate respondsToSelector:@selector(crashes:willSendErrorReport:)]) {
-    if ([((NSObject *)log) isKindOfClass:[MSAppleErrorLog class]]) {
-      MSErrorReport *report = [MSErrorLogFormatter errorReportFromLog:((MSAppleErrorLog *)log)];
+    NSObject *logObject = static_cast<NSObject *>(log);
+    if ([logObject isKindOfClass:[MSAppleErrorLog class]]) {
+      MSAppleErrorLog *appleErrorLog = static_cast<MSAppleErrorLog *>(log);
+      MSErrorReport *report = [MSErrorLogFormatter errorReportFromLog:appleErrorLog];
       [self.delegate crashes:self willSendErrorReport:report];
     }
   }
@@ -450,8 +453,10 @@ static void uncaught_cxx_exception_handler(const MSCrashesUncaughtCXXExceptionIn
 
 - (void)channel:(id<MSChannel>)channel didSucceedSendingLog:(id<MSLog>)log {
   if (self.delegate && [self.delegate respondsToSelector:@selector(crashes:didSucceedSendingErrorReport:)]) {
-    if ([((NSObject *)log) isKindOfClass:[MSAppleErrorLog class]]) {
-      MSErrorReport *report = [MSErrorLogFormatter errorReportFromLog:((MSAppleErrorLog *)log)];
+    NSObject *logObject = static_cast<NSObject *>(log);
+    if ([logObject isKindOfClass:[MSAppleErrorLog class]]) {
+      MSAppleErrorLog *appleErrorLog = static_cast<MSAppleErrorLog *>(log);
+      MSErrorReport *report = [MSErrorLogFormatter errorReportFromLog:appleErrorLog];
       [self.delegate crashes:self didSucceedSendingErrorReport:report];
     }
   }
@@ -459,8 +464,10 @@ static void uncaught_cxx_exception_handler(const MSCrashesUncaughtCXXExceptionIn
 
 - (void)channel:(id<MSChannel>)channel didFailSendingLog:(id<MSLog>)log withError:(NSError *)error {
   if (self.delegate && [self.delegate respondsToSelector:@selector(crashes:didFailSendingErrorReport:withError:)]) {
-    if ([((NSObject *)log) isKindOfClass:[MSAppleErrorLog class]]) {
-      MSErrorReport *report = [MSErrorLogFormatter errorReportFromLog:((MSAppleErrorLog *)log)];
+    NSObject *logObject = static_cast<NSObject *>(log);
+    if ([logObject isKindOfClass:[MSAppleErrorLog class]]) {
+      MSAppleErrorLog *appleErrorLog = static_cast<MSAppleErrorLog *>(log);
+      MSErrorReport *report = [MSErrorLogFormatter errorReportFromLog:appleErrorLog];
       [self.delegate crashes:self didFailSendingErrorReport:report withError:error];
     }
   }
@@ -639,7 +646,7 @@ static void uncaught_cxx_exception_handler(const MSCrashesUncaughtCXXExceptionIn
      * Get directory for priority, iterate over each file in it with the kMSLogBufferFileExtension and send
      * the log if a log can be deserialized.
      */
-    NSString *dirForPriority = [self bufferDirectoryForPriority:(MSPriority)priority];
+    NSString *dirForPriority = [self bufferDirectoryForPriority:MSPriority(priority)];
     NSArray *files = [[NSFileManager defaultManager] contentsOfDirectoryAtPath:dirForPriority error:NULL];
     for (NSString *tmp in files) {
       if ([[tmp pathExtension] isEqualToString:kMSLogBufferFileExtension]) {
@@ -648,7 +655,7 @@ static void uncaught_cxx_exception_handler(const MSCrashesUncaughtCXXExceptionIn
         if (serializedLog && serializedLog.length && serializedLog.length > 0) {
           id<MSLog> item = [NSKeyedUnarchiver unarchiveObjectWithData:serializedLog];
           if (item) {
-            [self.logManager processLog:item withPriority:(MSPriority)priority];
+            [self.logManager processLog:item withPriority:MSPriority(priority)];
           }
         }
 
@@ -760,11 +767,11 @@ static void uncaught_cxx_exception_handler(const MSCrashesUncaughtCXXExceptionIn
     for (NSInteger priority = 0; priority < kMSPriorityCount; priority++) {
 
       // Setup asynchronously.
-      NSArray *files = [self createBufferFilesIfNeededForPriority:(MSPriority)priority];
+      NSArray *files = [self createBufferFilesIfNeededForPriority:MSPriority(priority)];
 
       // Create a buffer for the priority. Making use of `{}` as we're using C++11.
       for (NSUInteger i = 0; i < ms_crashes_log_buffer_size; i++) {
-        msCrashesLogBuffer[(MSPriority)priority][i] = MSCrashesBufferedLog{files[i], nil};
+        msCrashesLogBuffer[MSPriority(priority)][i] = MSCrashesBufferedLog{files[i], nil};
       }
     }
   }
@@ -820,7 +827,7 @@ static void uncaught_cxx_exception_handler(const MSCrashesUncaughtCXXExceptionIn
 
 - (void)emptyLogBufferFiles {
   for (NSInteger priority = 0; priority < kMSPriorityCount; priority++) {
-    NSString *directoryForPriority = [self bufferDirectoryForPriority:(MSPriority)priority];
+    NSString *directoryForPriority = [self bufferDirectoryForPriority:MSPriority(priority)];
     NSArray *files = [[NSFileManager defaultManager] contentsOfDirectoryAtPath:directoryForPriority error:NULL];
     for (NSString *tmp in files) {
       if ([[tmp pathExtension] isEqualToString:kMSLogBufferFileExtension]) {


### PR DESCRIPTION
Fixed the warnings related to "use of old-style cast" (they are all in MSCrashes.mm).