### PR TITLE
Revert change to MSCrashes.mm’s log buffer feature that were introduc…

### DIFF
--- a/MobileCenterCrashes/MobileCenterCrashes/Internals/MSCrashesPrivate.h
+++ b/MobileCenterCrashes/MobileCenterCrashes/Internals/MSCrashesPrivate.h
@@ -24,8 +24,14 @@ struct MSCrashesBufferedLog {
 
   MSCrashesBufferedLog() = default;
 
-  MSCrashesBufferedLog(NSString *path)
-  : bufferPath(path.UTF8String) {}
+  MSCrashesBufferedLog(NSString *path, NSData *data)
+    : bufferPath(path.UTF8String), buffer(&reinterpret_cast<const char *>(data.bytes)[0], &reinterpret_cast<const char *>(data.bytes)[data.length]) {}
+  
+  
+    MSCrashesBufferedLog(NSString *path, NSData *data, NSString *internalLogId, NSString *logTimestamp)
+  : bufferPath(path.UTF8String), buffer(&reinterpret_cast<const char *>(data.bytes)[0],
+                                        &reinterpret_cast<const char *>(data.bytes)[data.length]),
+  internalId(internalLogId.UTF8String), timestamp(logTimestamp.UTF8String) {}
 };
 
 /**

--- a/MobileCenterCrashes/MobileCenterCrashes/Internals/MSCrashesPrivate.h
+++ b/MobileCenterCrashes/MobileCenterCrashes/Internals/MSCrashesPrivate.h
@@ -26,12 +26,6 @@ struct MSCrashesBufferedLog {
 
   MSCrashesBufferedLog(NSString *path, NSData *data)
     : bufferPath(path.UTF8String), buffer(&reinterpret_cast<const char *>(data.bytes)[0], &reinterpret_cast<const char *>(data.bytes)[data.length]) {}
-  
-  
-    MSCrashesBufferedLog(NSString *path, NSData *data, NSString *internalLogId, NSString *logTimestamp)
-  : bufferPath(path.UTF8String), buffer(&reinterpret_cast<const char *>(data.bytes)[0],
-                                        &reinterpret_cast<const char *>(data.bytes)[data.length]),
-  internalId(internalLogId.UTF8String), timestamp(logTimestamp.UTF8String) {}
 };
 
 /**


### PR DESCRIPTION
…ed in PR #405 

I overlooked this change in PR #405.
a) my comment explains why we init with `nil` and it also fixes the issue. Imho the old crash buffer logic actually renders the buffer useless. This would actually crash the app if we weren't already crashing (the data of msLogBuffer is accessed in post_crash_callback). 

cc @MatkovIvan 