### PR TITLE
Fix warning related to default case in MSLogger.

### DIFF
--- a/MobileCenter/MobileCenter/Internals/MSLogger.m
+++ b/MobileCenter/MobileCenter/Internals/MSLogger.m
@@ -34,11 +34,9 @@ MSLogHandler const msDefaultLogHandler = ^(MSLogMessageProvider messageProvider,
     case MSLogLevelAssert:
       level = @"ASSERT";
       break;
-    default:
-        
-      // Ignore if log level is not valid. Will never fall to this default case. Added the value to silence a warning.
+    case MSLogLevelNone:
       level = @"";
-      return;
+      break;
     }
     NSLog((@"[%@] %@: %s/%d %@"), tag, level, function, line, messageProvider());
   }


### PR DESCRIPTION
Fixed “no explicit case for MSLogLevelNone”-warning.
Having a default case results in a warning related to default covering all values of MSLogLevel-enum.
I chose this option as we want to have 0 warnings ASAP.