### PR TITLE
Feature/limit uikit imports in core

### DIFF
--- a/MobileCenter/MobileCenter/Internals/Device/MSDeviceTracker.m
+++ b/MobileCenter/MobileCenter/Internals/Device/MSDeviceTracker.m
@@ -6,6 +6,7 @@
 #import "MSWrapperSdkPrivate.h"
 #import "MSUserDefaults.h"
 #import "MSUtility+Date.h"
+#import "MSUtility+Application.h"
 
 // SDK versioning struct. Needs to be big enough to hold the info.
 typedef struct {

--- a/MobileCenter/MobileCenter/Internals/Device/MSDeviceTracker.m
+++ b/MobileCenter/MobileCenter/Internals/Device/MSDeviceTracker.m
@@ -5,8 +5,8 @@
 #import "MSDevicePrivate.h"
 #import "MSWrapperSdkPrivate.h"
 #import "MSUserDefaults.h"
-#import "MSUtility+Date.h"
 #import "MSUtility+Application.h"
+#import "MSUtility+Date.h"
 
 // SDK versioning struct. Needs to be big enough to hold the info.
 typedef struct {

--- a/MobileCenter/MobileCenter/Internals/Utils/MSKeychainUtil.h
+++ b/MobileCenter/MobileCenter/Internals/Utils/MSKeychainUtil.h
@@ -1,5 +1,4 @@
 #import <Foundation/Foundation.h>
-#import <UIKit/UIKit.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/MobileCenter/MobileCenter/Internals/Utils/MSUtility+Application.h
+++ b/MobileCenter/MobileCenter/Internals/Utils/MSUtility+Application.h
@@ -1,5 +1,9 @@
 #import <Foundation/Foundation.h>
+#import <UIKit/UIKit.h>
+
 #import "MSUtility.h"
+
+#define MS_DEVICE [UIDevice currentDevice]
 
 /*
  * Workaround for exporting symbols from category object files.

--- a/MobileCenter/MobileCenter/Internals/Utils/MSUtility+ApplicationPrivate.h
+++ b/MobileCenter/MobileCenter/Internals/Utils/MSUtility+ApplicationPrivate.h
@@ -1,7 +1,5 @@
 #import "MSUtility+Application.h"
 
-#import <UIKit/UIKit.h>
-
 /**
  * Utility class that is used throughout the SDK.
  * Application private part.

--- a/MobileCenter/MobileCenter/Internals/Utils/MSUtility.h
+++ b/MobileCenter/MobileCenter/Internals/Utils/MSUtility.h
@@ -1,9 +1,7 @@
 #import <Foundation/Foundation.h>
-#import <UIKit/UIKit.h>
 
 #define MS_USER_DEFAULTS [MSUserDefaults shared]
 #define MS_NOTIFICATION_CENTER [NSNotificationCenter defaultCenter]
-#define MS_DEVICE [UIDevice currentDevice]
 #define MS_UUID_STRING [[NSUUID UUID] UUIDString]
 #define MS_UUID_FROM_STRING(uuidString) [[NSUUID alloc] initWithUUIDString:uuidString]
 #define MS_LOCALE [NSLocale currentLocale]


### PR DESCRIPTION
We want to "contain" UIKIT imports as much as possible.
This limits the usage of UIKit some more.

One idea that I haven't committed:
Renaming `MSUtility+Application.h` to `MSUtility+UIKITh`. Whatcha think?