### PR TITLE
MSLogManagerDefault race condition fixed

### DIFF
--- a/MobileCenter/MobileCenter/Internals/Channel/MSLogManagerDefault.m
+++ b/MobileCenter/MobileCenter/Internals/Channel/MSLogManagerDefault.m
@@ -49,11 +49,15 @@ static char *const MSlogsDispatchQueue = "com.microsoft.azure.mobile.mobilecente
 #pragma mark - Delegate
 
 - (void)addDelegate:(id<MSLogManagerDelegate>)delegate {
-  [self.delegates addObject:delegate];
+  @synchronized (self) {
+    [self.delegates addObject:delegate];
+  }
 }
 
 - (void)removeDelegate:(id<MSLogManagerDelegate>)delegate {
-  [self.delegates removeObject:delegate];
+  @synchronized (self) {
+    [self.delegates removeObject:delegate];
+  }
 }
 
 #pragma mark - Channel Delegate
@@ -77,9 +81,11 @@ static char *const MSlogsDispatchQueue = "com.microsoft.azure.mobile.mobilecente
 }
 
 - (void)enumerateDelegatesForSelector:(SEL)selector withBlock:(void (^)(id<MSLogManagerDelegate> delegate))block {
-  for (id<MSLogManagerDelegate> delegate in self.delegates) {
-    if (delegate && [delegate respondsToSelector:selector]) {
-      block(delegate);
+  @synchronized (self) {
+    for (id<MSLogManagerDelegate> delegate in self.delegates) {
+      if (delegate && [delegate respondsToSelector:selector]) {
+        block(delegate);
+      }
     }
   }
 }

--- a/MobileCenter/MobileCenterTests/MSLogManagerDefaultTests.m
+++ b/MobileCenter/MobileCenterTests/MSLogManagerDefaultTests.m
@@ -71,4 +71,30 @@
   OCMVerify([mockDelegate onEnqueuingLog:log withInternalId:OCMOCK_ANY andPriority:priority]);
 }
 
+- (void)testDelegatesConcurrentAccess {
+  
+  // If
+  MSPriority priority = MSPriorityDefault;
+  NSString *groupID = @"MobileCenter";
+  MSLogManagerDefault *sut = [[MSLogManagerDefault alloc] initWithSender:OCMProtocolMock(@protocol(MSSender))
+                                                                 storage:OCMProtocolMock(@protocol(MSStorage))];
+  MSAbstractLog *log = [MSAbstractLog new];
+  for (int j = 0; j < 10; j++) {
+    id mockDelegate = OCMProtocolMock(@protocol(MSLogManagerDelegate));
+    [sut addDelegate: mockDelegate];
+  }
+  
+  // When
+  void (^block)() = ^{
+    for (int i = 0; i < 10; i++) {
+      [sut processLog:log withPriority:priority andGroupID:groupID];
+    }
+    for (int i = 0; i < 100; i++) {
+      [sut addDelegate: OCMProtocolMock(@protocol(MSLogManagerDelegate))];
+    }
+  };
+  
+  // Then
+  XCTAssertNoThrow(block());
+}
 @end

--- a/MobileCenter/MobileCenterTests/MSLogManagerDefaultTests.m
+++ b/MobileCenter/MobileCenterTests/MSLogManagerDefaultTests.m
@@ -81,7 +81,7 @@
   MSAbstractLog *log = [MSAbstractLog new];
   for (int j = 0; j < 10; j++) {
     id mockDelegate = OCMProtocolMock(@protocol(MSLogManagerDelegate));
-    [sut addDelegate: mockDelegate];
+    [sut addDelegate:mockDelegate];
   }
   
   // When
@@ -90,7 +90,7 @@
       [sut processLog:log withPriority:priority andGroupID:groupID];
     }
     for (int i = 0; i < 100; i++) {
-      [sut addDelegate: OCMProtocolMock(@protocol(MSLogManagerDelegate))];
+      [sut addDelegate:OCMProtocolMock(@protocol(MSLogManagerDelegate))];
     }
   };
   


### PR DESCRIPTION
There was a race condition while interacting with MSLogManagerDefault delegates collection, due to concurrent access from different threads. The issue can be reproduced with following code in Sasquatch app:
```
for index in 1...100 {
  mobileCenter.trackEvent("Row Clicked \(index)")
}
for index in 1...100 {
  mobileCenter.setAnalyticsEnabled(!mobileCenter.isAnalyticsEnabled())
}