### PR TITLE
Feature/reduce warnings

### DIFF
--- a/CrashLibIOS/CrashLibIOS.xcodeproj/project.pbxproj
+++ b/CrashLibIOS/CrashLibIOS.xcodeproj/project.pbxproj
@@ -263,7 +263,7 @@
 		B21A71D21DD2A38C0044BB1C /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0810;
+				LastUpgradeCheck = 0830;
 				ORGANIZATIONNAME = Microsoft;
 				TargetAttributes = {
 					B21A71DA1DD2A38C0044BB1C = {

--- a/CrashLibIOS/CrashLibIOS.xcodeproj/xcshareddata/xcschemes/CrashLibIOS.xcscheme
+++ b/CrashLibIOS/CrashLibIOS.xcodeproj/xcshareddata/xcschemes/CrashLibIOS.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0820"
+   LastUpgradeVersion = "0830"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Global.xcconfig
+++ b/Global.xcconfig
@@ -70,7 +70,12 @@ GCC_PREPROCESSOR_DEFINITIONS = $(inherited) $(XCODEBUILD_GCC_PREPROCESSOR_DEFINI
 // -global-constructors
 // Global constructors are obvious, no need to warn about them.
 
-WARNING_CFLAGS = -Weverything -Wno-objc-missing-property-synthesis -Wno-float-equal -Wno-pedantic -Wno-padded  -Wno-sign-conversion -Wno-c++98-compat -Wno-c++98-compat-pedantic -Wno-auto-import -Wno-assign-enum -Wno-exit-time-destructors -Wno-global-constructors 
+// -cast-align
+// We're not interested in this one as the Mach-O format is itself well-aligned and the original memory allocation
+// happens through malloc() and mmap() which always return at least 16byte alignment.
+// Reas more about alignment in the c++ reference: http://en.cppreference.com/w/cpp/language/object#Alignment.
+
+WARNING_CFLAGS = -Weverything -Wno-objc-missing-property-synthesis -Wno-float-equal -Wno-pedantic -Wno-padded  -Wno-sign-conversion -Wno-c++98-compat -Wno-c++98-compat-pedantic -Wno-auto-import -Wno-assign-enum -Wno-exit-time-destructors -Wno-global-constructors -Wno-cast-align
 
 
 // These are all partially (but not completely?) independent of WARNING_CFLAGS

--- a/Global.xcconfig
+++ b/Global.xcconfig
@@ -64,7 +64,10 @@ GCC_PREPROCESSOR_DEFINITIONS = $(inherited) $(XCODEBUILD_GCC_PREPROCESSOR_DEFINI
 // -assign-enum
 // A lot of api use enums as params but Apple's docs suggest passing in 0 which causes annoying warnings.
 
-WARNING_CFLAGS = -Weverything -Wno-objc-missing-property-synthesis -Wno-float-equal -Wno-pedantic -Wno-padded  -Wno-sign-conversion -Wno-c++98-compat -Wno-c++98-compat-pedantic -Wno-auto-import -Wno-assign-enum
+// -exit-time-destructors
+// Global destructors are obvious, no need to warn about them.
+
+WARNING_CFLAGS = -Weverything -Wno-objc-missing-property-synthesis -Wno-float-equal -Wno-pedantic -Wno-padded  -Wno-sign-conversion -Wno-c++98-compat -Wno-c++98-compat-pedantic -Wno-auto-import -Wno-assign-enum -Wno-exit-time-destructors
 
 
 // These are all partially (but not completely?) independent of WARNING_CFLAGS

--- a/Global.xcconfig
+++ b/Global.xcconfig
@@ -67,7 +67,10 @@ GCC_PREPROCESSOR_DEFINITIONS = $(inherited) $(XCODEBUILD_GCC_PREPROCESSOR_DEFINI
 // -exit-time-destructors
 // Global destructors are obvious, no need to warn about them.
 
-WARNING_CFLAGS = -Weverything -Wno-objc-missing-property-synthesis -Wno-float-equal -Wno-pedantic -Wno-padded  -Wno-sign-conversion -Wno-c++98-compat -Wno-c++98-compat-pedantic -Wno-auto-import -Wno-assign-enum -Wno-exit-time-destructors
+// -global-constructors
+// Global constructors are obvious, no need to warn about them.
+
+WARNING_CFLAGS = -Weverything -Wno-objc-missing-property-synthesis -Wno-float-equal -Wno-pedantic -Wno-padded  -Wno-sign-conversion -Wno-c++98-compat -Wno-c++98-compat-pedantic -Wno-auto-import -Wno-assign-enum -Wno-exit-time-destructors -Wno-global-constructors 
 
 
 // These are all partially (but not completely?) independent of WARNING_CFLAGS

--- a/MobileCenter.xcworkspace/xcshareddata/xcschemes/AllDoc+Frameworks.xcscheme
+++ b/MobileCenter.xcworkspace/xcshareddata/xcschemes/AllDoc+Frameworks.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0820"
+   LastUpgradeVersion = "0830"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/MobileCenter.xcworkspace/xcshareddata/xcschemes/AllLibraries.xcscheme
+++ b/MobileCenter.xcworkspace/xcshareddata/xcschemes/AllLibraries.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0820"
+   LastUpgradeVersion = "0830"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/MobileCenter/MobileCenter.xcodeproj/xcshareddata/xcschemes/MobileCenter.xcscheme
+++ b/MobileCenter/MobileCenter.xcodeproj/xcshareddata/xcschemes/MobileCenter.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0820"
+   LastUpgradeVersion = "0830"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/MobileCenter/MobileCenter.xcodeproj/xcshareddata/xcschemes/MobileCenterDoc.xcscheme
+++ b/MobileCenter/MobileCenter.xcodeproj/xcshareddata/xcschemes/MobileCenterDoc.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0820"
+   LastUpgradeVersion = "0830"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/MobileCenter/MobileCenter.xcodeproj/xcshareddata/xcschemes/MobileCenterFramework.xcscheme
+++ b/MobileCenter/MobileCenter.xcodeproj/xcshareddata/xcschemes/MobileCenterFramework.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0820"
+   LastUpgradeVersion = "0830"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/MobileCenter/MobileCenterTests/MSIngestionSenderTests.m
+++ b/MobileCenter/MobileCenterTests/MSIngestionSenderTests.m
@@ -73,7 +73,7 @@ static NSString *const kMSBaseUrl = @"https://test.com";
 
         XCTAssertNil(error);
         XCTAssertEqual(containerId, batchId);
-        XCTAssertEqual(statusCode, MSHTTPCodesNo200OK);
+        XCTAssertEqual((NSInteger)statusCode, MSHTTPCodesNo200OK);
 
         [expectation fulfill];
       }];
@@ -99,7 +99,7 @@ static NSString *const kMSBaseUrl = @"https://test.com";
                           NSError *error) {
 
         XCTAssertEqual(containerId, batchId);
-        XCTAssertEqual(statusCode, MSHTTPCodesNo404NotFound);
+        XCTAssertEqual((NSInteger)statusCode, MSHTTPCodesNo404NotFound);
         XCTAssertEqual(error.domain, kMSMCErrorDomain);
         XCTAssertEqual(error.code, kMSMCConnectionHttpErrorCode);
         XCTAssertEqual(error.localizedDescription, kMSMCConnectionHttpErrorDesc);

--- a/MobileCenter/MobileCenterTests/MSIngestionSenderTests.m
+++ b/MobileCenter/MobileCenterTests/MSIngestionSenderTests.m
@@ -73,7 +73,7 @@ static NSString *const kMSBaseUrl = @"https://test.com";
 
         XCTAssertNil(error);
         XCTAssertEqual(containerId, batchId);
-        XCTAssertEqual((NSInteger)statusCode, MSHTTPCodesNo200OK);
+        XCTAssertEqual(statusCode, MSHTTPCodesNo200OK);
 
         [expectation fulfill];
       }];
@@ -99,7 +99,7 @@ static NSString *const kMSBaseUrl = @"https://test.com";
                           NSError *error) {
 
         XCTAssertEqual(containerId, batchId);
-        XCTAssertEqual((NSInteger)statusCode, MSHTTPCodesNo404NotFound);
+        XCTAssertEqual(statusCode, MSHTTPCodesNo404NotFound);
         XCTAssertEqual(error.domain, kMSMCErrorDomain);
         XCTAssertEqual(error.code, kMSMCConnectionHttpErrorCode);
         XCTAssertEqual(error.localizedDescription, kMSMCConnectionHttpErrorDesc);

--- a/MobileCenterAnalytics/MobileCenterAnalytics.xcodeproj/xcshareddata/xcschemes/MobileCenterAnalytics.xcscheme
+++ b/MobileCenterAnalytics/MobileCenterAnalytics.xcodeproj/xcshareddata/xcschemes/MobileCenterAnalytics.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0820"
+   LastUpgradeVersion = "0830"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/MobileCenterAnalytics/MobileCenterAnalytics.xcodeproj/xcshareddata/xcschemes/MobileCenterAnalyticsDoc.xcscheme
+++ b/MobileCenterAnalytics/MobileCenterAnalytics.xcodeproj/xcshareddata/xcschemes/MobileCenterAnalyticsDoc.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0820"
+   LastUpgradeVersion = "0830"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/MobileCenterAnalytics/MobileCenterAnalytics.xcodeproj/xcshareddata/xcschemes/MobileCenterAnalyticsFramework.xcscheme
+++ b/MobileCenterAnalytics/MobileCenterAnalytics.xcodeproj/xcshareddata/xcschemes/MobileCenterAnalyticsFramework.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0820"
+   LastUpgradeVersion = "0830"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/MobileCenterCrashes/MobileCenterCrashes.xcodeproj/project.pbxproj
+++ b/MobileCenterCrashes/MobileCenterCrashes.xcodeproj/project.pbxproj
@@ -618,7 +618,7 @@
 			isa = PBXProject;
 			attributes = {
 				CLASSPREFIX = MS;
-				LastUpgradeCheck = 0820;
+				LastUpgradeCheck = 0830;
 				ORGANIZATIONNAME = Microsoft;
 				TargetAttributes = {
 					6E0401321D1C98690051BCFA = {

--- a/MobileCenterCrashes/MobileCenterCrashes.xcodeproj/xcshareddata/xcschemes/MobileCenterCrashes.xcscheme
+++ b/MobileCenterCrashes/MobileCenterCrashes.xcodeproj/xcshareddata/xcschemes/MobileCenterCrashes.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0820"
+   LastUpgradeVersion = "0830"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/MobileCenterCrashes/MobileCenterCrashes.xcodeproj/xcshareddata/xcschemes/MobileCenterCrashesDoc.xcscheme
+++ b/MobileCenterCrashes/MobileCenterCrashes.xcodeproj/xcshareddata/xcschemes/MobileCenterCrashesDoc.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0820"
+   LastUpgradeVersion = "0830"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/MobileCenterCrashes/MobileCenterCrashes.xcodeproj/xcshareddata/xcschemes/MobileCenterCrashesFramework.xcscheme
+++ b/MobileCenterCrashes/MobileCenterCrashes.xcodeproj/xcshareddata/xcschemes/MobileCenterCrashesFramework.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0820"
+   LastUpgradeVersion = "0830"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/MobileCenterCrashes/MobileCenterCrashes/Internals/MSWrapperExceptionManager.m
+++ b/MobileCenterCrashes/MobileCenterCrashes/Internals/MSWrapperExceptionManager.m
@@ -11,7 +11,7 @@
   return [[self sharedInstance] hasException];
 }
 
-+ (void)setWrapperException:(MSException*)wrapperException {
++ (void)setWrapperException:(MSException *)wrapperException {
   [self sharedInstance].wrapperException = wrapperException;
 }
 
@@ -19,11 +19,11 @@
   [[self sharedInstance] saveWrapperExceptionData:uuidRef];
 }
 
-+ (NSData*)loadWrapperExceptionDataWithUUIDString:(NSString*)uuidString {
++ (NSData *)loadWrapperExceptionDataWithUUIDString:(NSString *)uuidString {
   return [[self sharedInstance] loadWrapperExceptionDataWithUUIDString:uuidString];
 }
 
-+ (MSException*)loadWrapperException:(CFUUIDRef)uuidRef {
++ (MSException *)loadWrapperException:(CFUUIDRef)uuidRef {
   return [[self sharedInstance] loadWrapperException:uuidRef];
 }
 
@@ -43,14 +43,14 @@
   [[self sharedInstance] deleteAllWrapperExceptions];
 }
 
-+ (void)deleteWrapperExceptionDataWithUUIDString:(NSString*)uuidString {
++ (void)deleteWrapperExceptionDataWithUUIDString:(NSString *)uuidString {
   [[self sharedInstance] deleteWrapperExceptionDataWithUUIDString:uuidString];
 }
 + (void)deleteAllWrapperExceptionData {
   [[self sharedInstance] deleteAllWrapperExceptionData];
 }
 
-+ (void)setDelegate:(id<MSWrapperCrashesInitializationDelegate>) delegate {
++ (void)setDelegate:(id<MSWrapperCrashesInitializationDelegate>)delegate {
   [self sharedInstance].crashesDelegate = delegate;
 }
 
@@ -58,7 +58,7 @@
   return [self sharedInstance].crashesDelegate;
 }
 
-+ (void) startCrashReportingFromWrapperSdk {
++ (void)startCrashReportingFromWrapperSdk {
   [[self sharedInstance] startCrashReportingFromWrapperSdk];
 }
 
@@ -82,12 +82,12 @@
                                  attributes:nil
                                       error:&error];
       if (error) {
-        MSLogError([MSCrashes logTag], @"Failed to create directory %@: %@",
-                   [[self class] directoryPath], error.localizedDescription);
+        MSLogError([MSCrashes logTag], @"Failed to create directory %@: %@", [[self class] directoryPath],
+                   error.localizedDescription);
       }
     }
   }
-  
+
   return self;
 }
 
@@ -104,7 +104,7 @@
   return self.wrapperException != nil;
 }
 
-- (MSException*)loadWrapperException:(CFUUIDRef)uuidRef {
+- (MSException *)loadWrapperException:(CFUUIDRef)uuidRef {
   if (self.wrapperException && [[self class] isCurrentUUIDRef:uuidRef]) {
     return self.wrapperException;
   }
@@ -162,11 +162,11 @@
   if (!self.unsavedWrapperExceptionData) {
     return;
   }
-  NSString* dataFilename = [[self class] getDataFilenameWithUUIDRef:uuidRef];
+  NSString *dataFilename = [[self class] getDataFilenameWithUUIDRef:uuidRef];
   [self.unsavedWrapperExceptionData writeToFile:dataFilename atomically:YES];
 }
 
-- (NSData*)loadWrapperExceptionDataWithUUIDString:(NSString*)uuidString {
+- (NSData *)loadWrapperExceptionDataWithUUIDString:(NSString *)uuidString {
   NSString *dataFilename = [[self class] getDataFilename:uuidString];
   NSData *data = self.wrapperExceptionData[dataFilename];
   if (data) {
@@ -175,14 +175,13 @@
   NSError *error = nil;
   data = [NSData dataWithContentsOfFile:dataFilename options:NSDataReadingMappedIfSafe error:&error];
   if (error) {
-    MSLogError([MSCrashes logTag], @"Error loading file %@: %@",
-               dataFilename, error.localizedDescription);
+    MSLogError([MSCrashes logTag], @"Error loading file %@: %@", dataFilename, error.localizedDescription);
   }
   return data;
 }
 
-- (void)deleteWrapperExceptionDataWithUUIDString:(NSString*)uuidString {
-  NSString* dataFilename = [[self class] getDataFilename:uuidString];
+- (void)deleteWrapperExceptionDataWithUUIDString:(NSString *)uuidString {
+  NSString *dataFilename = [[self class] getDataFilename:uuidString];
   NSData *data = [self loadWrapperExceptionDataWithUUIDString:uuidString];
   if (data) {
     self.wrapperExceptionData[dataFilename] = data;
@@ -200,24 +199,23 @@
   }
 }
 
-+ (void)deleteFile:(NSString*)path {
++ (void)deleteFile:(NSString *)path {
   if (![[NSFileManager defaultManager] fileExistsAtPath:path]) {
     return;
   }
   NSError *error = nil;
   [[NSFileManager defaultManager] removeItemAtPath:path error:&error];
   if (error) {
-    MSLogError([MSCrashes logTag], @"Error deleting file %@: %@",
-               path, error.localizedDescription);
+    MSLogError([MSCrashes logTag], @"Error deleting file %@: %@", path, error.localizedDescription);
   }
 }
 
-+ (NSString*)uuidRefToString:(CFUUIDRef)uuidRef {
++ (NSString *)uuidRefToString:(CFUUIDRef)uuidRef {
   if (!uuidRef) {
     return nil;
   }
   CFStringRef uuidStringRef = CFUUIDCreateString(kCFAllocatorDefault, uuidRef);
-  return (__bridge_transfer NSString*)uuidStringRef;
+  return (__bridge_transfer NSString *)uuidStringRef;
 }
 
 + (BOOL)isCurrentUUIDRef:(CFUUIDRef)uuidRef {
@@ -240,21 +238,21 @@
   return [uuidString isEqualToString:currentUUIDString];
 }
 
-- (void) startCrashReportingFromWrapperSdk {
+- (void)startCrashReportingFromWrapperSdk {
   [[MSCrashes sharedInstance] configureCrashReporter];
 }
 
-+ (NSString*)dataFileExtension {
+- (NSString *)dataFileExtension {
   return @"ms";
 }
 
-+ (NSString*)directoryName {
+- (NSString *)directoryName {
   return @"wrapper_exceptions";
 }
 
-+ (NSString*)directoryPath {
+- (NSString *)directoryPath {
 
-  static NSString* path = nil;
+  static NSString *path = nil;
 
   if (!path) {
     NSArray *paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
@@ -265,27 +263,27 @@
   return path;
 }
 
-+ (NSString*)getFilename:(NSString*)uuidString {
-  return [[self directoryPath] stringByAppendingPathComponent:uuidString];
++ (NSString *)getFilename:(NSString *)uuidString {
+  return [[[self sharedInstance] directoryPath] stringByAppendingPathComponent:uuidString];
 }
 
-+ (NSString*)getDataFilename:(NSString*)uuidString {
++ (NSString *)getDataFilename:(NSString *)uuidString {
   NSString *filename = [MSWrapperExceptionManager getFilename:uuidString];
-  return [filename stringByAppendingPathExtension:[self dataFileExtension]];
+  return [filename stringByAppendingPathExtension:[[self sharedInstance] dataFileExtension]];
 }
 
-+ (NSString*)getFilenameWithUUIDRef:(CFUUIDRef)uuidRef {
++ (NSString *)getFilenameWithUUIDRef:(CFUUIDRef)uuidRef {
   NSString *uuidString = [MSWrapperExceptionManager uuidRefToString:uuidRef];
   return [MSWrapperExceptionManager getFilename:uuidString];
 }
 
-+ (NSString*)getDataFilenameWithUUIDRef:(CFUUIDRef)uuidRef {
++ (NSString *)getDataFilenameWithUUIDRef:(CFUUIDRef)uuidRef {
   NSString *uuidString = [MSWrapperExceptionManager uuidRefToString:uuidRef];
   return [MSWrapperExceptionManager getDataFilename:uuidString];
 }
 
-+ (BOOL) isDataFile:(NSString*)path {
-  return [path hasSuffix:[@"." stringByAppendingString:[self dataFileExtension]]];
++ (BOOL)isDataFile:(NSString *)path {
+  return [path hasSuffix:[@"." stringByAppendingString:[[self sharedInstance] dataFileExtension]]];
 }
 
 @end

--- a/MobileCenterCrashes/MobileCenterCrashes/Internals/MSWrapperExceptionManager.m
+++ b/MobileCenterCrashes/MobileCenterCrashes/Internals/MSWrapperExceptionManager.m
@@ -11,7 +11,7 @@
   return [[self sharedInstance] hasException];
 }
 
-+ (void)setWrapperException:(MSException *)wrapperException {
++ (void)setWrapperException:(MSException*)wrapperException {
   [self sharedInstance].wrapperException = wrapperException;
 }
 
@@ -19,11 +19,11 @@
   [[self sharedInstance] saveWrapperExceptionData:uuidRef];
 }
 
-+ (NSData *)loadWrapperExceptionDataWithUUIDString:(NSString *)uuidString {
++ (NSData*)loadWrapperExceptionDataWithUUIDString:(NSString*)uuidString {
   return [[self sharedInstance] loadWrapperExceptionDataWithUUIDString:uuidString];
 }
 
-+ (MSException *)loadWrapperException:(CFUUIDRef)uuidRef {
++ (MSException*)loadWrapperException:(CFUUIDRef)uuidRef {
   return [[self sharedInstance] loadWrapperException:uuidRef];
 }
 
@@ -43,14 +43,14 @@
   [[self sharedInstance] deleteAllWrapperExceptions];
 }
 
-+ (void)deleteWrapperExceptionDataWithUUIDString:(NSString *)uuidString {
++ (void)deleteWrapperExceptionDataWithUUIDString:(NSString*)uuidString {
   [[self sharedInstance] deleteWrapperExceptionDataWithUUIDString:uuidString];
 }
 + (void)deleteAllWrapperExceptionData {
   [[self sharedInstance] deleteAllWrapperExceptionData];
 }
 
-+ (void)setDelegate:(id<MSWrapperCrashesInitializationDelegate>)delegate {
++ (void)setDelegate:(id<MSWrapperCrashesInitializationDelegate>) delegate {
   [self sharedInstance].crashesDelegate = delegate;
 }
 
@@ -58,7 +58,7 @@
   return [self sharedInstance].crashesDelegate;
 }
 
-+ (void)startCrashReportingFromWrapperSdk {
++ (void) startCrashReportingFromWrapperSdk {
   [[self sharedInstance] startCrashReportingFromWrapperSdk];
 }
 
@@ -82,12 +82,12 @@
                                  attributes:nil
                                       error:&error];
       if (error) {
-        MSLogError([MSCrashes logTag], @"Failed to create directory %@: %@", [[self class] directoryPath],
-                   error.localizedDescription);
+        MSLogError([MSCrashes logTag], @"Failed to create directory %@: %@",
+                   [[self class] directoryPath], error.localizedDescription);
       }
     }
   }
-
+  
   return self;
 }
 
@@ -104,7 +104,7 @@
   return self.wrapperException != nil;
 }
 
-- (MSException *)loadWrapperException:(CFUUIDRef)uuidRef {
+- (MSException*)loadWrapperException:(CFUUIDRef)uuidRef {
   if (self.wrapperException && [[self class] isCurrentUUIDRef:uuidRef]) {
     return self.wrapperException;
   }
@@ -162,11 +162,11 @@
   if (!self.unsavedWrapperExceptionData) {
     return;
   }
-  NSString *dataFilename = [[self class] getDataFilenameWithUUIDRef:uuidRef];
+  NSString* dataFilename = [[self class] getDataFilenameWithUUIDRef:uuidRef];
   [self.unsavedWrapperExceptionData writeToFile:dataFilename atomically:YES];
 }
 
-- (NSData *)loadWrapperExceptionDataWithUUIDString:(NSString *)uuidString {
+- (NSData*)loadWrapperExceptionDataWithUUIDString:(NSString*)uuidString {
   NSString *dataFilename = [[self class] getDataFilename:uuidString];
   NSData *data = self.wrapperExceptionData[dataFilename];
   if (data) {
@@ -175,13 +175,14 @@
   NSError *error = nil;
   data = [NSData dataWithContentsOfFile:dataFilename options:NSDataReadingMappedIfSafe error:&error];
   if (error) {
-    MSLogError([MSCrashes logTag], @"Error loading file %@: %@", dataFilename, error.localizedDescription);
+    MSLogError([MSCrashes logTag], @"Error loading file %@: %@",
+               dataFilename, error.localizedDescription);
   }
   return data;
 }
 
-- (void)deleteWrapperExceptionDataWithUUIDString:(NSString *)uuidString {
-  NSString *dataFilename = [[self class] getDataFilename:uuidString];
+- (void)deleteWrapperExceptionDataWithUUIDString:(NSString*)uuidString {
+  NSString* dataFilename = [[self class] getDataFilename:uuidString];
   NSData *data = [self loadWrapperExceptionDataWithUUIDString:uuidString];
   if (data) {
     self.wrapperExceptionData[dataFilename] = data;
@@ -199,23 +200,24 @@
   }
 }
 
-+ (void)deleteFile:(NSString *)path {
++ (void)deleteFile:(NSString*)path {
   if (![[NSFileManager defaultManager] fileExistsAtPath:path]) {
     return;
   }
   NSError *error = nil;
   [[NSFileManager defaultManager] removeItemAtPath:path error:&error];
   if (error) {
-    MSLogError([MSCrashes logTag], @"Error deleting file %@: %@", path, error.localizedDescription);
+    MSLogError([MSCrashes logTag], @"Error deleting file %@: %@",
+               path, error.localizedDescription);
   }
 }
 
-+ (NSString *)uuidRefToString:(CFUUIDRef)uuidRef {
++ (NSString*)uuidRefToString:(CFUUIDRef)uuidRef {
   if (!uuidRef) {
     return nil;
   }
   CFStringRef uuidStringRef = CFUUIDCreateString(kCFAllocatorDefault, uuidRef);
-  return (__bridge_transfer NSString *)uuidStringRef;
+  return (__bridge_transfer NSString*)uuidStringRef;
 }
 
 + (BOOL)isCurrentUUIDRef:(CFUUIDRef)uuidRef {
@@ -238,21 +240,21 @@
   return [uuidString isEqualToString:currentUUIDString];
 }
 
-- (void)startCrashReportingFromWrapperSdk {
+- (void) startCrashReportingFromWrapperSdk {
   [[MSCrashes sharedInstance] configureCrashReporter];
 }
 
-- (NSString *)dataFileExtension {
++ (NSString*)dataFileExtension {
   return @"ms";
 }
 
-- (NSString *)directoryName {
++ (NSString*)directoryName {
   return @"wrapper_exceptions";
 }
 
-- (NSString *)directoryPath {
++ (NSString*)directoryPath {
 
-  static NSString *path = nil;
+  static NSString* path = nil;
 
   if (!path) {
     NSArray *paths = NSSearchPathForDirectoriesInDomains(NSDocumentDirectory, NSUserDomainMask, YES);
@@ -263,27 +265,27 @@
   return path;
 }
 
-+ (NSString *)getFilename:(NSString *)uuidString {
-  return [[[self sharedInstance] directoryPath] stringByAppendingPathComponent:uuidString];
++ (NSString*)getFilename:(NSString*)uuidString {
+  return [[self directoryPath] stringByAppendingPathComponent:uuidString];
 }
 
-+ (NSString *)getDataFilename:(NSString *)uuidString {
++ (NSString*)getDataFilename:(NSString*)uuidString {
   NSString *filename = [MSWrapperExceptionManager getFilename:uuidString];
-  return [filename stringByAppendingPathExtension:[[self sharedInstance] dataFileExtension]];
+  return [filename stringByAppendingPathExtension:[self dataFileExtension]];
 }
 
-+ (NSString *)getFilenameWithUUIDRef:(CFUUIDRef)uuidRef {
++ (NSString*)getFilenameWithUUIDRef:(CFUUIDRef)uuidRef {
   NSString *uuidString = [MSWrapperExceptionManager uuidRefToString:uuidRef];
   return [MSWrapperExceptionManager getFilename:uuidString];
 }
 
-+ (NSString *)getDataFilenameWithUUIDRef:(CFUUIDRef)uuidRef {
++ (NSString*)getDataFilenameWithUUIDRef:(CFUUIDRef)uuidRef {
   NSString *uuidString = [MSWrapperExceptionManager uuidRefToString:uuidRef];
   return [MSWrapperExceptionManager getDataFilename:uuidString];
 }
 
-+ (BOOL)isDataFile:(NSString *)path {
-  return [path hasSuffix:[@"." stringByAppendingString:[[self sharedInstance] dataFileExtension]]];
++ (BOOL) isDataFile:(NSString*)path {
+  return [path hasSuffix:[@"." stringByAppendingString:[self dataFileExtension]]];
 }
 
 @end

--- a/MobileCenterCrashes/MobileCenterCrashes/Internals/MSWrapperExceptionManagerInternal.h
+++ b/MobileCenterCrashes/MobileCenterCrashes/Internals/MSWrapperExceptionManagerInternal.h
@@ -8,31 +8,31 @@
 @property CFUUIDRef currentUUIDRef;
 @property(weak, nonatomic) id<MSWrapperCrashesInitializationDelegate> crashesDelegate;
 
-@property(class, copy, readonly) NSString *dataFileExtension;
-@property(class, copy, readonly) NSString *directoryName;
-@property(class, copy, readonly) NSString *directoryPath;
+@property(atomic, copy, readonly) NSString *dataFileExtension;
+@property(atomic, copy, readonly) NSString *directoryName;
+@property(atomic, copy, readonly) NSString *directoryPath;
 
-+ (MSWrapperExceptionManager*)sharedInstance;
++ (MSWrapperExceptionManager *)sharedInstance;
 - (BOOL)hasException;
-- (MSException*)loadWrapperException:(CFUUIDRef)uuidRef;
+- (MSException *)loadWrapperException:(CFUUIDRef)uuidRef;
 - (void)saveWrapperException:(CFUUIDRef)uuidRef;
 - (void)deleteWrapperExceptionWithUUID:(CFUUIDRef)uuidRef;
 - (void)deleteAllWrapperExceptions;
 - (void)deleteAllWrapperExceptionData;
 - (void)saveWrapperExceptionData:(CFUUIDRef)uuidRef;
 
-- (NSData*)loadWrapperExceptionDataWithUUIDString:(NSString*)uuidString;
-- (void)deleteWrapperExceptionDataWithUUIDString:(NSString*)uuidString;
+- (NSData *)loadWrapperExceptionDataWithUUIDString:(NSString *)uuidString;
+- (void)deleteWrapperExceptionDataWithUUIDString:(NSString *)uuidString;
 
-+ (NSString*)directoryPath;
+- (NSString *)directoryPath;
 
-+ (NSString*)getFilename:(NSString*)uuidString;
-+ (NSString*)getDataFilename:(NSString*)uuidString;
-+ (NSString*)getFilenameWithUUIDRef:(CFUUIDRef)uuidRef;
-+ (NSString*)getDataFilenameWithUUIDRef:(CFUUIDRef)uuidRef;
-+ (void)deleteFile:(NSString*)path;
-+ (BOOL)isDataFile:(NSString*)path;
-+ (NSString*)uuidRefToString:(CFUUIDRef)uuidRef;
++ (NSString *)getFilename:(NSString *)uuidString;
++ (NSString *)getDataFilename:(NSString *)uuidString;
++ (NSString *)getFilenameWithUUIDRef:(CFUUIDRef)uuidRef;
++ (NSString *)getDataFilenameWithUUIDRef:(CFUUIDRef)uuidRef;
++ (void)deleteFile:(NSString *)path;
++ (BOOL)isDataFile:(NSString *)path;
++ (NSString *)uuidRefToString:(CFUUIDRef)uuidRef;
 + (BOOL)isCurrentUUIDRef:(CFUUIDRef)uuidRef;
 - (void)startCrashReportingFromWrapperSdk;
 

--- a/MobileCenterCrashes/MobileCenterCrashes/Internals/MSWrapperExceptionManagerInternal.h
+++ b/MobileCenterCrashes/MobileCenterCrashes/Internals/MSWrapperExceptionManagerInternal.h
@@ -8,9 +8,9 @@
 @property CFUUIDRef currentUUIDRef;
 @property(weak, nonatomic) id<MSWrapperCrashesInitializationDelegate> crashesDelegate;
 
-@property(class, copy, readonly) NSString *dataFileExtension;
-@property(class, copy, readonly) NSString *directoryName;
-@property(class, copy, readonly) NSString *directoryPath;
+@property(copy, readonly) NSString *dataFileExtension;
+@property(copy, readonly) NSString *directoryName;
+@property(copy, readonly) NSString *directoryPath;
 
 + (MSWrapperExceptionManager*)sharedInstance;
 - (BOOL)hasException;

--- a/MobileCenterCrashes/MobileCenterCrashes/Internals/MSWrapperExceptionManagerInternal.h
+++ b/MobileCenterCrashes/MobileCenterCrashes/Internals/MSWrapperExceptionManagerInternal.h
@@ -8,31 +8,31 @@
 @property CFUUIDRef currentUUIDRef;
 @property(weak, nonatomic) id<MSWrapperCrashesInitializationDelegate> crashesDelegate;
 
-@property(atomic, copy, readonly) NSString *dataFileExtension;
-@property(atomic, copy, readonly) NSString *directoryName;
-@property(atomic, copy, readonly) NSString *directoryPath;
+@property(class, copy, readonly) NSString *dataFileExtension;
+@property(class, copy, readonly) NSString *directoryName;
+@property(class, copy, readonly) NSString *directoryPath;
 
-+ (MSWrapperExceptionManager *)sharedInstance;
++ (MSWrapperExceptionManager*)sharedInstance;
 - (BOOL)hasException;
-- (MSException *)loadWrapperException:(CFUUIDRef)uuidRef;
+- (MSException*)loadWrapperException:(CFUUIDRef)uuidRef;
 - (void)saveWrapperException:(CFUUIDRef)uuidRef;
 - (void)deleteWrapperExceptionWithUUID:(CFUUIDRef)uuidRef;
 - (void)deleteAllWrapperExceptions;
 - (void)deleteAllWrapperExceptionData;
 - (void)saveWrapperExceptionData:(CFUUIDRef)uuidRef;
 
-- (NSData *)loadWrapperExceptionDataWithUUIDString:(NSString *)uuidString;
-- (void)deleteWrapperExceptionDataWithUUIDString:(NSString *)uuidString;
+- (NSData*)loadWrapperExceptionDataWithUUIDString:(NSString*)uuidString;
+- (void)deleteWrapperExceptionDataWithUUIDString:(NSString*)uuidString;
 
-- (NSString *)directoryPath;
++ (NSString*)directoryPath;
 
-+ (NSString *)getFilename:(NSString *)uuidString;
-+ (NSString *)getDataFilename:(NSString *)uuidString;
-+ (NSString *)getFilenameWithUUIDRef:(CFUUIDRef)uuidRef;
-+ (NSString *)getDataFilenameWithUUIDRef:(CFUUIDRef)uuidRef;
-+ (void)deleteFile:(NSString *)path;
-+ (BOOL)isDataFile:(NSString *)path;
-+ (NSString *)uuidRefToString:(CFUUIDRef)uuidRef;
++ (NSString*)getFilename:(NSString*)uuidString;
++ (NSString*)getDataFilename:(NSString*)uuidString;
++ (NSString*)getFilenameWithUUIDRef:(CFUUIDRef)uuidRef;
++ (NSString*)getDataFilenameWithUUIDRef:(CFUUIDRef)uuidRef;
++ (void)deleteFile:(NSString*)path;
++ (BOOL)isDataFile:(NSString*)path;
++ (NSString*)uuidRefToString:(CFUUIDRef)uuidRef;
 + (BOOL)isCurrentUUIDRef:(CFUUIDRef)uuidRef;
 - (void)startCrashReportingFromWrapperSdk;
 

--- a/MobileCenterCrashes/MobileCenterCrashes/Internals/Utils/MSErrorLogFormatterPrivate.h
+++ b/MobileCenterCrashes/MobileCenterCrashes/Internals/Utils/MSErrorLogFormatterPrivate.h
@@ -6,8 +6,8 @@
 
 /**
  * Remove user information from a path when the crash happened in the simulator.
- * @param path
- * @return
+ * @param path The path that needs to be anonymized.
+ * @return The anonymized path.
  */
 + (NSString *)anonymizedPathFromPath:(NSString *)path;
 
@@ -27,7 +27,7 @@
  *
  * @param errorLog The error log object that will be returned.
  * @param crashReport The crash
- * @return
+ * @return The error log with process informaton and the application path.
  */
 + (MSAppleErrorLog *)addProcessInfoAndApplicationPathTo:(MSAppleErrorLog *)errorLog
                                          fromCrashReport:(MSPLCrashReport *)crashReport;

--- a/MobileCenterCrashes/MobileCenterCrashesTests/MSAppleErrorLogTests.m
+++ b/MobileCenterCrashes/MobileCenterCrashesTests/MSAppleErrorLogTests.m
@@ -57,7 +57,7 @@
   appleLog.parentProcessName = @"234";
   appleLog.errorThreadId = @2;
   appleLog.errorThreadName = @"2";
-  appleLog.fatal = @YES;
+  appleLog.fatal = YES;
   appleLog.appLaunchTOffset = @123;
   appleLog.errorAttachment = [MSErrorAttachment attachmentWithText:@"test"];
   appleLog.architecture = @"test";

--- a/MobileCenterCrashes/MobileCenterCrashesTests/MSCrashesTests.mm
+++ b/MobileCenterCrashes/MobileCenterCrashesTests/MSCrashesTests.mm
@@ -113,8 +113,9 @@ static NSString *const kMSCrashesServiceName = @"Crashes";
   [MSCrashes setDelegate:delegateMock];
 
   // Then
-  XCTAssertNotNil([MSCrashes sharedInstance].delegate);
-  XCTAssertEqual([MSCrashes sharedInstance].delegate, delegateMock);
+  id<MSCrashesDelegate> strongDelegate = [MSCrashes sharedInstance].delegate;
+  XCTAssertNotNil(strongDelegate);
+  XCTAssertEqual(strongDelegate, delegateMock);
 }
 
 - (void)testDelegateMethodsAreCalled {

--- a/MobileCenterDistribute/MobileCenterDistribute.xcodeproj/project.pbxproj
+++ b/MobileCenterDistribute/MobileCenterDistribute.xcodeproj/project.pbxproj
@@ -83,7 +83,6 @@
 		BA682AC831677E0806CA2359 /* MSErrorDetails.h in Headers */ = {isa = PBXBuildFile; fileRef = BA6820A043C816916AF34A04 /* MSErrorDetails.h */; };
 		BA682C81BA750CA5FCB63A51 /* MSErrorDetails.m in Sources */ = {isa = PBXBuildFile; fileRef = BA6826E3C58372A269A6B43A /* MSErrorDetails.m */; };
 		D377A3121E83C16400B2C97A /* MSMockUserDefaults.m in Sources */ = {isa = PBXBuildFile; fileRef = D377A3111E83C16400B2C97A /* MSMockUserDefaults.m */; };
-		F861639B1E76A04A00E3F06C /* Tests.xcconfig in Resources */ = {isa = PBXBuildFile; fileRef = F861639A1E76A04A00E3F06C /* Tests.xcconfig */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -548,7 +547,7 @@
 			isa = PBXProject;
 			attributes = {
 				CLASSPREFIX = MS;
-				LastUpgradeCheck = 0820;
+				LastUpgradeCheck = 0830;
 				ORGANIZATIONNAME = Microsoft;
 				TargetAttributes = {
 					04FD4A1B1E451E12009B4468 = {
@@ -619,7 +618,6 @@
 			files = (
 				B2C070C51E5E6A200076D6A9 /* MobileCenterDistributeResources.bundle in Resources */,
 				040AF0121E523AC2005C1174 /* release_details.json in Resources */,
-				F861639B1E76A04A00E3F06C /* Tests.xcconfig in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -743,6 +741,7 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				APPLICATION_EXTENSION_API_ONLY = YES;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";
@@ -793,6 +792,7 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				APPLICATION_EXTENSION_API_ONLY = YES;
+				CLANG_ANALYZER_LOCALIZABILITY_NONLOCALIZED = YES;
 				CLANG_ANALYZER_NONNULL = YES;
 				CLANG_CXX_LANGUAGE_STANDARD = "gnu++0x";
 				CLANG_CXX_LIBRARY = "libc++";

--- a/MobileCenterDistribute/MobileCenterDistribute.xcodeproj/xcshareddata/xcschemes/MobileCenterDistribute.xcscheme
+++ b/MobileCenterDistribute/MobileCenterDistribute.xcodeproj/xcshareddata/xcschemes/MobileCenterDistribute.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0820"
+   LastUpgradeVersion = "0830"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/MobileCenterDistribute/MobileCenterDistribute.xcodeproj/xcshareddata/xcschemes/MobileCenterDistributeDoc.xcscheme
+++ b/MobileCenterDistribute/MobileCenterDistribute.xcodeproj/xcshareddata/xcschemes/MobileCenterDistributeDoc.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0820"
+   LastUpgradeVersion = "0830"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/MobileCenterDistribute/MobileCenterDistribute.xcodeproj/xcshareddata/xcschemes/MobileCenterDistributeFramework.xcscheme
+++ b/MobileCenterDistribute/MobileCenterDistribute.xcodeproj/xcshareddata/xcschemes/MobileCenterDistributeFramework.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0820"
+   LastUpgradeVersion = "0830"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/MobileCenterDistribute/MobileCenterDistribute.xcodeproj/xcshareddata/xcschemes/MobileCenterDistributeResources.xcscheme
+++ b/MobileCenterDistribute/MobileCenterDistribute.xcodeproj/xcshareddata/xcschemes/MobileCenterDistributeResources.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0820"
+   LastUpgradeVersion = "0830"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/MobileCenterDistribute/MobileCenterDistribute/MSDistribute.m
+++ b/MobileCenterDistribute/MobileCenterDistribute/MSDistribute.m
@@ -550,7 +550,7 @@ static NSString *const kMSUpdateTokenURLInvalidErrorDescFormat = @"Invalid updat
       }];
 }
 
-- (void)closeApp {
+- (void)closeApp __attribute__((noreturn)) {
   exit(0);
 }
 

--- a/Puppet/Puppet.xcodeproj/xcshareddata/xcschemes/Puppet.xcscheme
+++ b/Puppet/Puppet.xcodeproj/xcshareddata/xcschemes/Puppet.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0820"
+   LastUpgradeVersion = "0830"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Puppet/Puppet.xcodeproj/xcshareddata/xcschemes/PuppetWidget.xcscheme
+++ b/Puppet/Puppet.xcodeproj/xcshareddata/xcschemes/PuppetWidget.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0820"
+   LastUpgradeVersion = "0830"
    wasCreatedForAppExtension = "YES"
    version = "2.0">
    <BuildAction

--- a/Sasquatch/Sasquatch.xcodeproj/xcshareddata/xcschemes/SasquatchObjC.xcscheme
+++ b/Sasquatch/Sasquatch.xcodeproj/xcshareddata/xcschemes/SasquatchObjC.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0820"
+   LastUpgradeVersion = "0830"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/Sasquatch/Sasquatch.xcodeproj/xcshareddata/xcschemes/SasquatchSwift.xcscheme
+++ b/Sasquatch/Sasquatch.xcodeproj/xcshareddata/xcschemes/SasquatchSwift.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0820"
+   LastUpgradeVersion = "0830"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"


### PR DESCRIPTION
I'm down to 9 warnings locally. It will be even less with the other PRs.

* Resolve warnings in Crashes
* Update to Xcode 8.3 for all modules
* Fix for unit test in MSAppleErrorLogTests