### PR TITLE
Fix distribute ui test for puppet app

### DIFF
--- a/Puppet/PuppetUITests/DistributeUITests.swift
+++ b/Puppet/PuppetUITests/DistributeUITests.swift
@@ -32,7 +32,7 @@ class DistributeUITests: XCTestCase {
 
     // Go to distribute page and find "Set Enabled" button.
     app.tables.cells.element(boundBy: DistributeCellIndex).tap();
-    let distributeButton : XCUIElement = app.switches.element(boundBy: 0);
+    let distributeButton : XCUIElement = app.switches.element(matching: XCUIElementType.switch, identifier: "Set Enabled");
 
     // Service should be enabled by default.
     XCTAssertEqual("1", distributeButton.value as! String);

--- a/Sasquatch/SasquatchUITests/DistributeUITests.swift
+++ b/Sasquatch/SasquatchUITests/DistributeUITests.swift
@@ -32,7 +32,7 @@ class DistributeUITests: XCTestCase {
 
     // Go to distribute page and find "Set Enabled" button.
     app.tables.cells.element(boundBy: DistributeCellIndex).tap();
-    let distributeButton : XCUIElement = app.switches.element(boundBy: 0);
+    let distributeButton : XCUIElement = app.switches.element(matching: XCUIElementType.switch, identifier: "Set Enabled");
 
     // Service should be enabled by default.
     XCTAssertEqual("1", distributeButton.value as! String);


### PR DESCRIPTION
We used to take the first element of UISwitch, because it was the only one. Now there are two such elements. And we need a second so now we choose by ID