### PR TITLE
Fix channel not resumed while app back in foreground

### DIFF
--- a/MobileCenter/MobileCenter.xcodeproj/project.pbxproj
+++ b/MobileCenter/MobileCenter.xcodeproj/project.pbxproj
@@ -46,6 +46,7 @@
 		380A4DCB1DD6908A00E99219 /* MSUtilityTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 380A4DCA1DD6908A00E99219 /* MSUtilityTests.m */; };
 		381C91E91D3DB65D004512F1 /* MSDeviceTracker.h in Headers */ = {isa = PBXBuildFile; fileRef = 381C91E51D3DB65D004512F1 /* MSDeviceTracker.h */; };
 		381C91EA1D3DB65D004512F1 /* MSDeviceTracker.m in Sources */ = {isa = PBXBuildFile; fileRef = 381C91E61D3DB65D004512F1 /* MSDeviceTracker.m */; };
+		382CFCF11EC3817B003FE40B /* MSChannelDefaultPrivate.h in Headers */ = {isa = PBXBuildFile; fileRef = 382CFCF01EC3817B003FE40B /* MSChannelDefaultPrivate.h */; };
 		384772A61DA5691F009365DE /* MSSenderDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 384772A51DA5691F009365DE /* MSSenderDelegate.h */; };
 		384959D51D491D4F008F6B3A /* MSMobileCenterTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 384959D41D491D4F008F6B3A /* MSMobileCenterTests.m */; };
 		385AD9221D95898D008B354A /* MSServiceAbstractProtected.h in Headers */ = {isa = PBXBuildFile; fileRef = 385AD9211D95898D008B354A /* MSServiceAbstractProtected.h */; };
@@ -204,6 +205,7 @@
 		380A4DCA1DD6908A00E99219 /* MSUtilityTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSUtilityTests.m; sourceTree = "<group>"; };
 		381C91E51D3DB65D004512F1 /* MSDeviceTracker.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MSDeviceTracker.h; sourceTree = "<group>"; };
 		381C91E61D3DB65D004512F1 /* MSDeviceTracker.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSDeviceTracker.m; sourceTree = "<group>"; };
+		382CFCF01EC3817B003FE40B /* MSChannelDefaultPrivate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MSChannelDefaultPrivate.h; sourceTree = "<group>"; };
 		384772A51DA5691F009365DE /* MSSenderDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MSSenderDelegate.h; sourceTree = "<group>"; };
 		384959D41D491D4F008F6B3A /* MSMobileCenterTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MSMobileCenterTests.m; sourceTree = "<group>"; };
 		385AD9211D95898D008B354A /* MSServiceAbstractProtected.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MSServiceAbstractProtected.h; sourceTree = "<group>"; };
@@ -654,6 +656,7 @@
 				E84B8E2D1D2351DB006FD231 /* MSLogManagerDefault.m */,
 				04FD126E1E415697007ABFE7 /* MSLogManagerDefaultPrivate.h */,
 				6E0684651D36BCD500A8CC6C /* MSChannel.h */,
+				382CFCF01EC3817B003FE40B /* MSChannelDefaultPrivate.h */,
 				6E0684611D36BC8D00A8CC6C /* MSChannelDefault.h */,
 				6E0684621D36BC8D00A8CC6C /* MSChannelDefault.m */,
 				6EF628F21D371B1600CAFF64 /* MSChannelConfiguration.h */,
@@ -701,6 +704,7 @@
 				E8E48F951D50FF4300A8C1B0 /* MSSenderCallDelegate.h in Headers */,
 				E83283C61D46C62E000B029E /* MS_Reachability.h in Headers */,
 				6E04016B1D1C9E1F0051BCFA /* MSConstants.h in Headers */,
+				382CFCF11EC3817B003FE40B /* MSChannelDefaultPrivate.h in Headers */,
 				B2FD53621E56501B0050F909 /* MSDeviceHistoryInfo.h in Headers */,
 				E8010E6A1D2DD4EF0035196F /* MSLogWithProperties.h in Headers */,
 				6E04016D1D1C9E460051BCFA /* MobileCenter+Internal.h in Headers */,

--- a/MobileCenter/MobileCenter/Internals/Channel/MSChannel.h
+++ b/MobileCenter/MobileCenter/Internals/Channel/MSChannel.h
@@ -1,3 +1,5 @@
+#import <Foundation/Foundation.h>
+
 #import "MSChannelConfiguration.h"
 #import "MSConstants+Internal.h"
 #import "MSEnable.h"
@@ -5,10 +7,6 @@
 #import "MSSender.h"
 #import "MSSenderDelegate.h"
 #import "MSStorage.h"
-#import <Foundation/Foundation.h>
-
-#import "MSEnable.h"
-#import "MSSenderDelegate.h"
 
 @protocol MSChannelDelegate;
 

--- a/MobileCenter/MobileCenter/Internals/Channel/MSChannel.h
+++ b/MobileCenter/MobileCenter/Internals/Channel/MSChannel.h
@@ -7,6 +7,9 @@
 #import "MSStorage.h"
 #import <Foundation/Foundation.h>
 
+#import "MSEnable.h"
+#import "MSSenderDelegate.h"
+
 @protocol MSChannelDelegate;
 
 NS_ASSUME_NONNULL_BEGIN

--- a/MobileCenter/MobileCenter/Internals/Channel/MSChannelDefault.m
+++ b/MobileCenter/MobileCenter/Internals/Channel/MSChannelDefault.m
@@ -287,11 +287,9 @@
   dispatch_async(self.logsDispatchQueue, ^{
     if (self.enabled != isEnabled) {
       self.enabled = isEnabled;
-      if (isEnabled) {
+      if (isEnabled && !self.sender.suspended) {
         [self resume];
-        [self.sender addDelegate:self];
       } else {
-        [self.sender removeDelegate:self];
         [self suspend];
       }
     }
@@ -317,7 +315,7 @@
 
 - (void)suspend {
   if (!self.suspended) {
-    MSLogDebug([MSMobileCenter logTag], @"Suspend channel.");
+    MSLogDebug([MSMobileCenter logTag], @"Suspend channel for group Id %@.", self.configuration.groupId);
     self.suspended = YES;
     [self resetTimer];
   }
@@ -325,7 +323,7 @@
 
 - (void)resume {
   if (self.suspended && self.enabled) {
-    MSLogDebug([MSMobileCenter logTag], @"Resume channel.");
+    MSLogDebug([MSMobileCenter logTag], @"Resume channel for group Id %@.", self.configuration.groupId);
     self.suspended = NO;
     self.discardLogs = NO;
     [self flushQueue];
@@ -371,13 +369,6 @@
   dispatch_async(self.logsDispatchQueue, ^{
     [self resume];
   });
-}
-
-- (void)sender:(id<MSSender>)sender didSetEnabled:(BOOL)isEnabled andDeleteDataOnDisabled:(BOOL)deleteData {
-  (void)sender;
-
-  // Reflect sender enabled state.
-  [self setEnabled:isEnabled andDeleteDataOnDisabled:deleteData];
 }
 
 #pragma mark - Helper

--- a/MobileCenter/MobileCenter/Internals/Channel/MSChannelDefault.m
+++ b/MobileCenter/MobileCenter/Internals/Channel/MSChannelDefault.m
@@ -227,12 +227,6 @@
                           // Remove from pending logs.
                           [self.pendingBatchIds removeObject:senderBatchId];
                           [self.storage deleteLogsForId:senderBatchId withGroupId:self.configuration.groupId];
-
-                          // Fatal error, disable sender with data deletion.
-                          // This will in turn disable this channel and delete logs.
-                          if (error.code != NSURLErrorCancelled) {
-                            [self.sender setEnabled:NO andDeleteDataOnDisabled:YES];
-                          }
                         }
                       } else
                         MSLogWarning([MSMobileCenter logTag], @"Batch Id %@ not expected, ignore.", senderBatchId);
@@ -296,7 +290,7 @@
 
     // Even if it's already disabled we might also want to delete logs this time.
     if (!isEnabled && deleteData) {
-      MSLogDebug([MSMobileCenter logTag], @"Delete all logs.");
+      MSLogDebug([MSMobileCenter logTag], @"Delete all logs for goup Id %@", self.configuration.groupId);
       NSError *error = [NSError errorWithDomain:kMSMCErrorDomain
                                            code:kMSMCConnectionSuspendedErrorCode
                                        userInfo:@{NSLocalizedDescriptionKey : kMSMCConnectionSuspendedErrorDesc}];
@@ -369,6 +363,13 @@
   dispatch_async(self.logsDispatchQueue, ^{
     [self resume];
   });
+}
+
+- (void)senderDidReceiveFatalError:(id<MSSender>)sender {
+  (void)sender;
+  
+  // Disable and delete data on fatal errors.
+  [self setEnabled:NO andDeleteDataOnDisabled:YES];
 }
 
 #pragma mark - Helper

--- a/MobileCenter/MobileCenter/Internals/Channel/MSChannelDefault.m
+++ b/MobileCenter/MobileCenter/Internals/Channel/MSChannelDefault.m
@@ -1,34 +1,7 @@
 #import "MSChannelDefault.h"
+#import "MSChannelDefaultPrivate.h"
 #import "MSMobileCenterErrors.h"
 #import "MSMobileCenterInternal.h"
-
-/**
- * Private declarations.
- */
-@interface MSChannelDefault ()
-
-/**
- * A boolean value set to YES if the channel is enabled or NO otherwise.
- * Enable/disable does resume/suspend the channel as needed under the hood.
- * When a channel is disabled with data deletion it deletes persisted logs and discards incoming logs.
- */
-@property(nonatomic) BOOL enabled;
-
-/**
- * A boolean value set to YES if the channel is suspended or NO otherwise.
- * A channel is suspended when it becomes disabled or when its sender becomes suspended itself.
- * A suspended channel doesn't forward logs to the sender.
- * A suspended state doesn't impact the current enabled state.
- */
-@property(nonatomic) BOOL suspended;
-
-/**
- * A boolean value set to YES if logs are discarded (not persisted) or NO otherwise.
- * Logs are discarded when the related service is disabled or an unrecoverable error happened.
- */
-@property(nonatomic) BOOL discardLogs;
-
-@end
 
 @implementation MSChannelDefault
 
@@ -281,8 +254,10 @@
   dispatch_async(self.logsDispatchQueue, ^{
     if (self.enabled != isEnabled) {
       self.enabled = isEnabled;
-      if (isEnabled && !self.sender.suspended) {
-        [self resume];
+      if (isEnabled) {
+        if (!self.sender.suspended){
+          [self resume];
+        }
       } else {
         [self suspend];
       }

--- a/MobileCenter/MobileCenter/Internals/Channel/MSChannelDefaultPrivate.h
+++ b/MobileCenter/MobileCenter/Internals/Channel/MSChannelDefaultPrivate.h
@@ -1,0 +1,29 @@
+#import "MSChannelDefault.h"
+
+/**
+ * Private declarations.
+ */
+@interface MSChannelDefault ()
+
+/**
+ * A boolean value set to YES if the channel is enabled or NO otherwise.
+ * Enable/disable does resume/suspend the channel as needed under the hood.
+ * When a channel is disabled with data deletion it deletes persisted logs and discards incoming logs.
+ */
+@property(nonatomic) BOOL enabled;
+
+/**
+ * A boolean value set to YES if the channel is suspended or NO otherwise.
+ * A channel is suspended when it becomes disabled or when its sender becomes suspended itself.
+ * A suspended channel doesn't forward logs to the sender.
+ * A suspended state doesn't impact the current enabled state.
+ */
+@property(nonatomic) BOOL suspended;
+
+/**
+ * A boolean value set to YES if logs are discarded (not persisted) or NO otherwise.
+ * Logs are discarded when the related service is disabled or an unrecoverable error happened.
+ */
+@property(nonatomic) BOOL discardLogs;
+
+@end

--- a/MobileCenter/MobileCenter/Internals/Channel/MSLogManager.h
+++ b/MobileCenter/MobileCenter/Internals/Channel/MSLogManager.h
@@ -78,6 +78,16 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)removeChannelDelegate:(id<MSChannelDelegate>)channelDelegate forGroupId:(NSString *)groupId;
 
+/**
+ * Suspend log manager, logs will not be sent but still stored.
+ */
+- (void)suspend;
+
+/**
+ * Resume log manager, logs can be sent again.
+ */
+- (void)resume;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/MobileCenter/MobileCenter/Internals/Channel/MSLogManagerDefault.m
+++ b/MobileCenter/MobileCenter/Internals/Channel/MSLogManagerDefault.m
@@ -164,8 +164,12 @@ static char *const MSlogsDispatchQueue = "com.microsoft.azure.mobile.mobilecente
     self.enabled = isEnabled;
 
     // Propagate to sender.
-    // Sender will in turn propagates to its channel delegates.
     [self.sender setEnabled:isEnabled andDeleteDataOnDisabled:deleteData];
+    
+    // Propagate to initialized channels.
+    for (NSString *groupId in self.channels) {
+      [self.channels[groupId] setEnabled:isEnabled andDeleteDataOnDisabled:deleteData];
+    }
 
     // If requested, also delete logs from not started services.
     if (!isEnabled && deleteData) {
@@ -188,6 +192,20 @@ static char *const MSlogsDispatchQueue = "com.microsoft.azure.mobile.mobilecente
   } else {
     MSLogWarning([MSMobileCenter logTag], @"Channel has not been initialized for the group ID: %@", groupId);
   }
+}
+
+#pragma mark - Suspend / Resume
+
+-(void)suspend{
+  
+  // Disable sender, sending log will not be possible but they'll still be stored.
+  [self.sender setEnabled:NO andDeleteDataOnDisabled:NO];
+}
+
+-(void)resume{
+  
+  // Resume sender, logs can be sent again. Pending logs are sent.
+  [self.sender setEnabled:YES andDeleteDataOnDisabled:NO];
 }
 
 #pragma mark - Other public methods

--- a/MobileCenter/MobileCenter/Internals/Channel/MSLogManagerDefault.m
+++ b/MobileCenter/MobileCenter/Internals/Channel/MSLogManagerDefault.m
@@ -61,13 +61,13 @@ static char *const MSlogsDispatchQueue = "com.microsoft.azure.mobile.mobilecente
 #pragma mark - Delegate
 
 - (void)addDelegate:(id<MSLogManagerDelegate>)delegate {
-  @synchronized (self) {
+  @synchronized(self) {
     [self.delegates addObject:delegate];
   }
 }
 
 - (void)removeDelegate:(id<MSLogManagerDelegate>)delegate {
-  @synchronized (self) {
+  @synchronized(self) {
     [self.delegates removeObject:delegate];
   }
 }
@@ -95,7 +95,7 @@ static char *const MSlogsDispatchQueue = "com.microsoft.azure.mobile.mobilecente
 }
 
 - (void)enumerateDelegatesForSelector:(SEL)selector withBlock:(void (^)(id<MSLogManagerDelegate> delegate))block {
-  @synchronized (self) {
+  @synchronized(self) {
     for (id<MSLogManagerDelegate> delegate in self.delegates) {
       if (delegate && [delegate respondsToSelector:selector]) {
         block(delegate);
@@ -165,7 +165,7 @@ static char *const MSlogsDispatchQueue = "com.microsoft.azure.mobile.mobilecente
 
     // Propagate to sender.
     [self.sender setEnabled:isEnabled andDeleteDataOnDisabled:deleteData];
-    
+
     // Propagate to initialized channels.
     for (NSString *groupId in self.channels) {
       [self.channels[groupId] setEnabled:isEnabled andDeleteDataOnDisabled:deleteData];
@@ -196,14 +196,14 @@ static char *const MSlogsDispatchQueue = "com.microsoft.azure.mobile.mobilecente
 
 #pragma mark - Suspend / Resume
 
--(void)suspend{
-  
+- (void)suspend {
+
   // Disable sender, sending log will not be possible but they'll still be stored.
   [self.sender setEnabled:NO andDeleteDataOnDisabled:NO];
 }
 
--(void)resume{
-  
+- (void)resume {
+
   // Resume sender, logs can be sent again. Pending logs are sent.
   [self.sender setEnabled:YES andDeleteDataOnDisabled:NO];
 }

--- a/MobileCenter/MobileCenter/Internals/MSMobileCenterPrivate.h
+++ b/MobileCenter/MobileCenter/Internals/MSMobileCenterPrivate.h
@@ -13,4 +13,13 @@
 // TODO: Move to MSMobileCenter.h when backend is ready.
 + (void)setCustomProperties:(MSCustomProperties *)customProperties;
 
+/**
+ * Configure the SDK.
+ *
+ * @discussion This may be called only once per application process lifetime.
+ * @param appSecret A unique and secret key used to identify the application.
+ */
+// FIXME: Rename to configureWithAppSecret
+- (BOOL)configure:(NSString *)appSecret;
+
 @end

--- a/MobileCenter/MobileCenter/Internals/Sender/MSHttpSender.m
+++ b/MobileCenter/MobileCenter/Internals/Sender/MSHttpSender.m
@@ -87,8 +87,10 @@ static NSString *const kMSPartialURLComponentsName[] = {@"scheme", @"user", @"pa
     if (self.enabled != isEnabled) {
       self.enabled = isEnabled;
       if (isEnabled) {
-        [self resume];
         [self.reachability startNotifier];
+        
+        // Apply current network state, this will resume if network state allows it.
+        [self networkStateChanged];
       } else {
         [self.reachability stopNotifier];
         [self suspend];
@@ -104,13 +106,6 @@ static NSString *const kMSPartialURLComponentsName[] = {@"scheme", @"user", @"pa
           [self.pendingCalls removeAllObjects];
         }
       }
-
-      // Forward enabled state.
-      [self
-          enumerateDelegatesForSelector:@selector(senderDidSuspend:)
-                              withBlock:^(id<MSSenderDelegate> delegate) {
-                                [delegate sender:self didSetEnabled:(BOOL)isEnabled andDeleteDataOnDisabled:deleteData];
-                              }];
     }
   }
 }

--- a/MobileCenter/MobileCenter/Internals/Sender/MSSender.h
+++ b/MobileCenter/MobileCenter/Internals/Sender/MSSender.h
@@ -1,8 +1,9 @@
+#import <Foundation/Foundation.h>
+
 #import "MSEnable.h"
 #import "MSSenderCallDelegate.h"
 #import "MSSenderUtil.h"
 #import "MS_Reachability.h"
-#import <Foundation/Foundation.h>
 
 NS_ASSUME_NONNULL_BEGIN
 

--- a/MobileCenter/MobileCenter/Internals/Sender/MSSenderCall.m
+++ b/MobileCenter/MobileCenter/Internals/Sender/MSSenderCall.m
@@ -86,8 +86,9 @@
 
   // Callback to Channel.
   else {
+    BOOL fatalError;
 
-    // Wrap the status code in an error.
+    // Wrap the status code in an error whenever the call failed.
     if (!error && statusCode != MSHTTPCodesNo200OK) {
       NSDictionary *userInfo = @{
         NSLocalizedDescriptionKey : kMSMCConnectionHttpErrorDesc,
@@ -95,12 +96,15 @@
       };
       error = [NSError errorWithDomain:kMSMCErrorDomain code:kMSMCConnectionHttpErrorCode userInfo:userInfo];
     }
+    
+    // Detect fatal error.
+    fatalError = (error && error.code != NSURLErrorCancelled);
 
     // Call completion.
     self.completionHandler(self.callId, statusCode, data, error);
 
     // Remove call from sender.
-    [sender callCompletedWithId:self.callId];
+    [sender call:self completedWithFatalError:fatalError];
   }
 }
 

--- a/MobileCenter/MobileCenter/Internals/Sender/MSSenderCallDelegate.h
+++ b/MobileCenter/MobileCenter/Internals/Sender/MSSenderCallDelegate.h
@@ -14,8 +14,8 @@
 /**
  *  Call completed callback.
  *
- *  @param callId call id.
+ *  @param call Call object.
  */
-- (void)callCompletedWithId:(NSString *)callId;
+- (void)call:(MSSenderCall *)call completedWithFatalError:(BOOL)fatalError;
 
 @end

--- a/MobileCenter/MobileCenter/Internals/Sender/MSSenderDelegate.h
+++ b/MobileCenter/MobileCenter/Internals/Sender/MSSenderDelegate.h
@@ -18,13 +18,4 @@
  */
 - (void)senderDidResume:(id<MSSender>)sender;
 
-/**
- *  Triggered after the sender has set its enabled state.
- *
- *  @param sender     Sender.
- *  @param isEnabled  A boolean reflecting the sender's enabled state.
- *  @param deleteData A boolean value set to YES if sender's data deletion was requested, NO otherwise.
- */
-- (void)sender:(id<MSSender>)sender didSetEnabled:(BOOL)isEnabled andDeleteDataOnDisabled:(BOOL)deleteData;
-
 @end

--- a/MobileCenter/MobileCenter/Internals/Sender/MSSenderDelegate.h
+++ b/MobileCenter/MobileCenter/Internals/Sender/MSSenderDelegate.h
@@ -18,4 +18,11 @@
  */
 - (void)senderDidResume:(id<MSSender>)sender;
 
+/**
+ * Triggered when sender receives a fatal error.
+ *
+ * @param sender Sender.
+ */
+- (void)senderDidReceiveFatalError:(id<MSSender>)sender;
+
 @end

--- a/MobileCenter/MobileCenter/MSMobileCenter.m
+++ b/MobileCenter/MobileCenter/MSMobileCenter.m
@@ -391,14 +391,14 @@ static NSString *const kMSGroupId = @"MobileCenter";
  *  The application will go to the foreground.
  */
 - (void)applicationWillEnterForeground {
-  [self.logManager setEnabled:YES andDeleteDataOnDisabled:NO];
+  [self.logManager resume];
 }
 
 /**
  *  The application will go to the background.
  */
 - (void)applicationDidEnterBackground {
-  [self.logManager setEnabled:NO andDeleteDataOnDisabled:NO];
+  [self.logManager suspend];
 }
 
 @end

--- a/MobileCenter/MobileCenterTests/MSIngestionSenderTests.m
+++ b/MobileCenter/MobileCenterTests/MSIngestionSenderTests.m
@@ -88,16 +88,20 @@ static NSString *const kMSBaseUrl = @"https://test.com";
 
 - (void)testUnrecoverableError {
 
-  // Stub http response
+  // If
   [MSHttpTestUtil stubHttp404Response];
   NSString *containerId = @"1";
   MSLogContainer *container = [self createLogContainerWithId:containerId];
-
   __weak XCTestExpectation *expectation = [self expectationWithDescription:@"HTTP Response 200"];
+  id delegateMock = OCMProtocolMock(@protocol(MSSenderDelegate));
+  [self.sut addDelegate:delegateMock];
+  
+  // When
   [self.sut sendAsync:container
       completionHandler:^(NSString *batchId, NSUInteger statusCode, __attribute__((unused)) NSData *data,
                           NSError *error) {
-
+        
+        // Then
         XCTAssertEqual(containerId, batchId);
         XCTAssertEqual((MSHTTPCodesNo)statusCode, MSHTTPCodesNo404NotFound);
         XCTAssertEqual(error.domain, kMSMCErrorDomain);
@@ -107,8 +111,11 @@ static NSString *const kMSBaseUrl = @"https://test.com";
         [expectation fulfill];
       }];
 
+  // Then
   [self waitForExpectationsWithTimeout:kMSTestTimeout
                                handler:^(NSError *_Nullable error) {
+                                 assertThatBool(self.sut.enabled, isFalse());
+                                 OCMVerify([delegateMock senderDidReceiveFatalError:self.sut]);
                                  if (error) {
                                    XCTFail(@"Expectation Failed with error: %@", error);
                                  }

--- a/MobileCenter/MobileCenterTests/MSLogManagerDefaultTests.m
+++ b/MobileCenter/MobileCenterTests/MSLogManagerDefaultTests.m
@@ -6,6 +6,7 @@
 #import "MSAbstractLog.h"
 #import "MSChannelConfiguration.h"
 #import "MSChannelDefault.h"
+#import "MSHttpSenderPrivate.h"
 #import "MSLogManagerDefault.h"
 #import "MSLogManagerDefaultPrivate.h"
 
@@ -112,5 +113,37 @@
   
   // Then
   XCTAssertNoThrow(block());
+}
+
+- (void)testResume{
+  
+  // If
+  MSHttpSender *senderMock = OCMClassMock([MSHttpSender class]);
+  id storageMock = OCMProtocolMock(@protocol(MSStorage));
+  
+  // When
+  MSLogManagerDefault *sut = [[MSLogManagerDefault alloc] initWithSender:senderMock storage:storageMock];
+  
+  // When
+  [sut resume];
+  
+  // Then
+  OCMVerify([senderMock setEnabled:YES andDeleteDataOnDisabled:NO]);
+}
+
+- (void)testSuspend{
+  
+  // If
+  MSHttpSender *senderMock = OCMClassMock([MSHttpSender class]);
+  id storageMock = OCMProtocolMock(@protocol(MSStorage));
+  
+  // When
+  MSLogManagerDefault *sut = [[MSLogManagerDefault alloc] initWithSender:senderMock storage:storageMock];
+  
+  // When
+  [sut suspend];
+  
+  // Then
+  OCMVerify([senderMock setEnabled:NO andDeleteDataOnDisabled:NO]);
 }
 @end

--- a/MobileCenter/MobileCenterTests/MSMobileCenterTests.m
+++ b/MobileCenter/MobileCenterTests/MSMobileCenterTests.m
@@ -194,4 +194,34 @@ static NSString *const kMSNullifiedInstallIdString = @"00000000-0000-0000-0000-0
   XCTAssertTrue([sorted[1] initializationPriority] == MSInitializationPriorityDefault);
 }
 
+- (void)testAppIsBackgrounded {
+
+  // If
+  id<MSLogManager> logManager = OCMProtocolMock(@protocol(MSLogManager));
+  [self.sut configure:@"AnAppSecret"];
+  self.sut.logManager = logManager;
+
+  
+  // When
+  [[NSNotificationCenter defaultCenter] postNotificationName:UIApplicationDidEnterBackgroundNotification
+                                                        object:self.sut];
+  // Then
+  OCMVerify([logManager suspend]);
+}
+
+- (void)testAppIsForegrounded {
+  
+  // If
+  id<MSLogManager> logManager = OCMProtocolMock(@protocol(MSLogManager));
+  [self.sut configure:@"AnAppSecret"];
+  self.sut.logManager = logManager;
+  
+  
+  // When
+  [[NSNotificationCenter defaultCenter] postNotificationName:UIApplicationWillEnterForegroundNotification
+                                                      object:self.sut];
+  // Then
+  OCMVerify([logManager resume]);
+}
+
 @end


### PR DESCRIPTION
* Don't disable logmanager while going in background but suspend it
* Don't enable logmanager while going in foreground but resume it
* Going background/foreground disable/enable sender
* Disabling/enabling sender does suspend/resume its delegate channels
* Channels enabled state not chained with sender anymore
* Explicitly disable/enable channels while log manager is disabling/enabling