### PR TITLE
Feature/swizzling deep dive

### DIFF
--- a/MobileCenter/MobileCenter/Internals/Application Delegate/MSAppDelegateForwarder.m
+++ b/MobileCenter/MobileCenter/Internals/Application Delegate/MSAppDelegateForwarder.m
@@ -123,7 +123,7 @@ static BOOL _enabled = YES;
   // Replace original implementation by the custom one.
   if (originalMethod) {
     originalImp = method_setImplementation(originalMethod, customImp);
-  } else {
+  } else if (![originalClass instancesRespondToSelector:originalSelector]) {
 
     /*
      * The original class may not implement the selector (e.g.: optional method from protocol),
@@ -132,6 +132,12 @@ static BOOL _enabled = YES;
     Method customMethod = class_getInstanceMethod(self, customSelector);
     methodAdded = class_addMethod(originalClass, originalSelector, customImp, method_getTypeEncoding(customMethod));
   }
+
+  /*
+   * If class instances respond to the selector but no implementation is found it's likely that the original class
+   * is doing message forwarding, in this case we can't add our implementation to the class or we will break the
+   * forwarding.
+   */
 
   // Validate swizzling.
   if (!originalImp && !methodAdded) {
@@ -172,8 +178,8 @@ static BOOL _enabled = YES;
 
 /*
  * Those methods will never get called but their implementation will be used by swizzling.
- * Those implementations will run within the delegate context.
- * Meaning that `self` will point to the original app delegate and not this forwarder.
+ * Those implementations will run within the delegate context. Meaning that `self` will point
+ * to the original app delegate and not this forwarder.
  */
 
 - (BOOL)application:(UIApplication *)app

--- a/MobileCenter/MobileCenterTests/MSAppDelegateForwarderTests.m
+++ b/MobileCenter/MobileCenterTests/MSAppDelegateForwarderTests.m
@@ -23,7 +23,6 @@
 #pragma clang diagnostic ignored "-Warc-retain-cycles"
 
 // Silence application:openURL:options: availability warning (iOS 9) for the whole test.
-#pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wpartial-availability"
 
 @implementation MSAppDelegateForwarderTest

--- a/MobileCenter/MobileCenterTests/MSAppDelegateForwarderTests.m
+++ b/MobileCenter/MobileCenterTests/MSAppDelegateForwarderTests.m
@@ -22,6 +22,10 @@
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Warc-retain-cycles"
 
+// Silence application:openURL:options: availability warning (iOS 9) for the whole test.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpartial-availability"
+
 @implementation MSAppDelegateForwarderTest
 
 - (void)setUp {
@@ -42,33 +46,186 @@
 }
 
 - (void)testAddAppDelegateSelectorToSwizzle {
-  
+
   // If
   NSUInteger currentCount = MSAppDelegateForwarder.selectorsToSwizzle.count;
   SEL expectedSelector = @selector(testAddAppDelegateSelectorToSwizzle);
   NSString *expectedSelectorStr = NSStringFromSelector(expectedSelector);
-  
+
   // Then
   assertThatBool([MSAppDelegateForwarder.selectorsToSwizzle containsObject:expectedSelectorStr], isFalse());
-  
+
   // When
   [MSAppDelegateForwarder addAppDelegateSelectorToSwizzle:expectedSelector];
-  
+
   // Then
-  assertThatInteger(MSAppDelegateForwarder.selectorsToSwizzle.count, equalToInteger(currentCount+1));
+  assertThatInteger(MSAppDelegateForwarder.selectorsToSwizzle.count, equalToInteger(currentCount + 1));
   assertThatBool([MSAppDelegateForwarder.selectorsToSwizzle containsObject:expectedSelectorStr], isTrue());
-  
+
   // When
   [MSAppDelegateForwarder addAppDelegateSelectorToSwizzle:expectedSelector];
-  
+
   // Then
-  assertThatInteger(MSAppDelegateForwarder.selectorsToSwizzle.count, equalToInteger(currentCount+1));
+  assertThatInteger(MSAppDelegateForwarder.selectorsToSwizzle.count, equalToInteger(currentCount + 1));
   assertThatBool([MSAppDelegateForwarder.selectorsToSwizzle containsObject:expectedSelectorStr], isTrue());
   [MSAppDelegateForwarder.selectorsToSwizzle removeObject:expectedSelectorStr];
 }
 
+- (void)testSwizzleOriginalDelegate {
+
+  /*
+   * If
+   */
+
+  // Mock a custom app delegate.
+  id<MSAppDelegate> customDelegate = OCMProtocolMock(@protocol(MSAppDelegate));
+  [MSAppDelegateForwarder addDelegate:customDelegate];
+  NSURL *expectedURL = [NSURL URLWithString:@"https://www.contoso.com/sending-positive-waves"];
+  NSDictionary *expectedOptions = @{};
+
+  // App delegate not implementing any selector.
+  Class originalAppDelegateClass = [self createClassConformingToProtocol:@protocol(UIApplicationDelegate)];
+  id<UIApplicationDelegate> originalAppDelegate = [originalAppDelegateClass new];
+  SEL selectorToSwizzle = @selector(application:openURL:options:);
+  [MSAppDelegateForwarder addAppDelegateSelectorToSwizzle:selectorToSwizzle];
+
+  /*
+   * When
+   */
+  [MSAppDelegateForwarder swizzleOriginalDelegate:originalAppDelegate];
+  [originalAppDelegate application:self.appMock openURL:expectedURL options:expectedOptions];
+
+  /*
+   * Then
+   */
+  assertThatBool([originalAppDelegate respondsToSelector:selectorToSwizzle], isTrue());
+  OCMVerify([customDelegate application:self.appMock openURL:expectedURL options:expectedOptions returnedValue:NO]);
+
+  /*
+   * If
+   */
+
+  // App delegate implementing the selector directly.
+  originalAppDelegateClass = [self createClassConformingToProtocol:@protocol(UIApplicationDelegate)];
+  __block BOOL wasCalled = NO;
+  id selectorImp = ^{
+    wasCalled = YES;
+    return YES;
+  };
+  const char *types = method_getTypeEncoding(class_getInstanceMethod(originalAppDelegateClass, selectorToSwizzle));
+  [self addSelector:selectorToSwizzle implementation:selectorImp types:types toClass:originalAppDelegateClass];
+  originalAppDelegate = [originalAppDelegateClass new];
+  [MSAppDelegateForwarder addAppDelegateSelectorToSwizzle:selectorToSwizzle];
+
+  /*
+   * When
+   */
+  [MSAppDelegateForwarder swizzleOriginalDelegate:originalAppDelegate];
+  [originalAppDelegate application:self.appMock openURL:expectedURL options:expectedOptions];
+
+  /*
+   * Then
+   */
+  assertThatBool([originalAppDelegate respondsToSelector:selectorToSwizzle], isTrue());
+  assertThatBool(wasCalled, isTrue());
+  OCMVerify([customDelegate application:self.appMock openURL:expectedURL options:expectedOptions returnedValue:YES]);
+
+  /*
+   * If
+   */
+
+  // App delegate implementing the selector indirectly.
+  Class baseClass = [self createClassConformingToProtocol:@protocol(UIApplicationDelegate)];
+  [self addSelector:selectorToSwizzle implementation:selectorImp types:types toClass:baseClass];
+  originalAppDelegateClass = [self createClassWithBaseClass:baseClass andConformItToProtocol:nil];
+  wasCalled = NO;
+  originalAppDelegate = [originalAppDelegateClass new];
+  [MSAppDelegateForwarder addAppDelegateSelectorToSwizzle:selectorToSwizzle];
+
+  /*
+   * When
+   */
+  [MSAppDelegateForwarder swizzleOriginalDelegate:originalAppDelegate];
+  [originalAppDelegate application:self.appMock openURL:expectedURL options:expectedOptions];
+
+  /*
+   * Then
+   */
+  assertThatBool([originalAppDelegate respondsToSelector:selectorToSwizzle], isTrue());
+  assertThatBool(wasCalled, isTrue());
+  OCMVerify([customDelegate application:self.appMock openURL:expectedURL options:expectedOptions returnedValue:YES]);
+
+  /*
+   * If
+   */
+
+  // App delegate implementing the selector directly and indirectly.
+  wasCalled = NO;
+  __block BOOL baseWasCalled = NO;
+  id baseSelectorImp = ^{
+    baseWasCalled = YES;
+  };
+  baseClass = [self createClassConformingToProtocol:@protocol(UIApplicationDelegate)];
+  [self addSelector:selectorToSwizzle implementation:baseSelectorImp types:types toClass:baseClass];
+  originalAppDelegateClass = [self createClassWithBaseClass:baseClass andConformItToProtocol:nil];
+  [self addSelector:selectorToSwizzle implementation:selectorImp types:types toClass:originalAppDelegateClass];
+  originalAppDelegate = [originalAppDelegateClass new];
+  [MSAppDelegateForwarder addAppDelegateSelectorToSwizzle:selectorToSwizzle];
+
+  /*
+   * When
+   */
+  [MSAppDelegateForwarder swizzleOriginalDelegate:originalAppDelegate];
+  [originalAppDelegate application:self.appMock openURL:expectedURL options:expectedOptions];
+
+  /*
+   * Then
+   */
+  assertThatBool([originalAppDelegate respondsToSelector:selectorToSwizzle], isTrue());
+  assertThatBool(wasCalled, isTrue());
+  assertThatBool(baseWasCalled, isFalse());
+  OCMVerify([customDelegate application:self.appMock openURL:expectedURL options:expectedOptions returnedValue:YES]);
+
+  /*
+   * If
+   */
+
+  // App delegate not implementing any selector still responds to selector.
+  originalAppDelegateClass = [self createClassConformingToProtocol:@protocol(UIApplicationDelegate)];
+  SEL instancesRespondToSelector = @selector(instancesRespondToSelector:);
+  id instancesRespondToSelectorImp = ^{
+    return YES;
+  };
+  const char *instancesRespondToSelectorTypes =
+      method_getTypeEncoding(class_getClassMethod(originalAppDelegateClass, instancesRespondToSelector));
+
+  // Adding a class method to a class requires its meta class.
+  Class originalAppDelegateMetaClass = object_getClass(originalAppDelegateClass);
+  [self addSelector:instancesRespondToSelector
+      implementation:instancesRespondToSelectorImp
+               types:instancesRespondToSelectorTypes
+             toClass:originalAppDelegateMetaClass];
+  originalAppDelegate = [originalAppDelegateClass new];
+  [MSAppDelegateForwarder addAppDelegateSelectorToSwizzle:selectorToSwizzle];
+
+  /*
+   * When
+   */
+  [MSAppDelegateForwarder swizzleOriginalDelegate:originalAppDelegate];
+
+  /*
+   * Then
+   */
+
+  // Original delegate still responding to selector.
+  assertThatBool([originalAppDelegateClass instancesRespondToSelector:selectorToSwizzle], isTrue());
+
+  // Swizzling did not happened so no method added/replaced for this selector.
+  assertThatBool(class_getInstanceMethod(originalAppDelegateClass, selectorToSwizzle) == NULL, isTrue());
+}
+
 - (void)testForwardUnknownSelector {
-  
+
   /*
    * If
    */
@@ -270,7 +427,9 @@
   NSString *customOpenURLiOS42Selector =
       NSStringFromSelector(@selector(application:openURL:sourceApplication:annotation:returnedValue:));
   self.appDelegateMock.customDelegateValidators[customOpenURLiOS42Selector] =
-      ^(__attribute__((unused))UIApplication *application, __attribute__((unused))NSURL *url, __attribute__((unused))NSString *sApplication, __attribute__((unused))id annotation, __attribute__((unused))BOOL returnedValue) {
+      ^(__attribute__((unused)) UIApplication *application, __attribute__((unused)) NSURL *url,
+        __attribute__((unused)) NSString *sApplication, __attribute__((unused)) id annotation,
+        __attribute__((unused)) BOOL returnedValue) {
 
         // Then
         XCTFail(@"Custom delegate got called but is removed.");
@@ -436,16 +595,40 @@
   [MSAppDelegateForwarder addDelegate:self.appDelegateMock];
 
   // When
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wpartial-availability"
   BOOL returnedValue = [self.appDelegateMock application:self.appMock openURL:expectedURL options:expectedOptions];
-#pragma clang diagnostic pop
 
   // Then
   assertThatBool(returnedValue, is(@(expectedReturnedValue)));
   [self waitForExpectations:@[ customCalledExpectation ] timeout:1];
 }
 
-#pragma clang diagnostic pop
+#pragma mark - Private
+
+- (NSString *)generateClassName {
+  return [@"C" stringByAppendingString:MS_UUID_STRING];
+}
+
+- (Class)createClassConformingToProtocol:(Protocol *)protocol {
+  return [self createClassWithBaseClass:[NSObject class] andConformItToProtocol:protocol];
+}
+
+- (Class)createClassWithBaseClass:(Class) class andConformItToProtocol:(Protocol *)protocol {
+
+  // Generate class name to prevent conflicts in runtime added classes.
+  Class newClass = objc_allocateClassPair(class, [[self generateClassName] UTF8String], 0);
+  if (protocol) {
+    class_addProtocol(newClass, protocol);
+  }
+  objc_registerClassPair(newClass);
+  return newClass;
+}
+
+    - (void)addSelector : (SEL)selector implementation : (id)block types : (const char *)types toClass : (Class) class {
+  IMP imp = imp_implementationWithBlock(block);
+  class_addMethod(class, selector, imp, types);
+}
 
 @end
+
+#pragma clang diagnostic pop
+


### PR DESCRIPTION
    Make sure swizzling is covering original delegate inheritance.
    
    * Add unit tests to cover inheritance over original app delegate
    * Try to prevent conflicts as much as possible with original delegates doing message forwarding