### PR TITLE
Remove LIBCXXABI_NORETURN macro that doesn't exist in Xcode 9 anymore

### DIFF
--- a/MobileCenterCrashes/MobileCenterCrashes/Internals/MSCrashesCXXExceptionHandler.mm
+++ b/MobileCenterCrashes/MobileCenterCrashes/Internals/MSCrashesCXXExceptionHandler.mm
@@ -25,7 +25,7 @@ static pthread_key_t _MSCrashesCXXExceptionInfoTSDKey = 0;
 
 @implementation MSCrashesUncaughtCXXExceptionHandlerManager
 
-extern "C" void LIBCXXABI_NORETURN __cxa_throw(void *exception_object, std::type_info *tinfo, void (*dest)(void *)) {
+extern "C" void __cxa_throw(void *exception_object, std::type_info *tinfo, void (*dest)(void *)) {
   /**
    * Purposely do not take a lock in this function. The aim is to be as fast as
    * possible. While we could really use some of the info set up by the real
@@ -40,7 +40,7 @@ extern "C" void LIBCXXABI_NORETURN __cxa_throw(void *exception_object, std::type
    * version).
    */
 
-  typedef void (*cxa_throw_func)(void *, std::type_info *, void (*)(void *)) LIBCXXABI_NORETURN;
+  typedef void (*cxa_throw_func)(void *, std::type_info *, void (*)(void *));
   static dispatch_once_t predicate = 0;
   static cxa_throw_func __original__cxa_throw = nullptr;
   static const void **__real_objc_ehtype_vtable = nullptr;


### PR DESCRIPTION
This fixes building in Xcode 9. The macro wasn't really necessary in the first place as the compiler could infer that info easily anyway. With the new Xcode 9, the macro appears to have been removed entirely.