### PR TITLE
Bring back "noreturn" attribute in C++ exception handler

### DIFF
--- a/MobileCenterCrashes/MobileCenterCrashes/Internals/MSCrashesCXXExceptionHandler.mm
+++ b/MobileCenterCrashes/MobileCenterCrashes/Internals/MSCrashesCXXExceptionHandler.mm
@@ -25,7 +25,7 @@ static pthread_key_t _MSCrashesCXXExceptionInfoTSDKey = 0;
 
 @implementation MSCrashesUncaughtCXXExceptionHandlerManager
 
-extern "C" void __cxa_throw(void *exception_object, std::type_info *tinfo, void (*dest)(void *)) {
+extern "C" void __attribute__((noreturn)) __cxa_throw(void *exception_object, std::type_info *tinfo, void (*dest)(void *)) {
   /**
    * Purposely do not take a lock in this function. The aim is to be as fast as
    * possible. While we could really use some of the info set up by the real
@@ -40,7 +40,7 @@ extern "C" void __cxa_throw(void *exception_object, std::type_info *tinfo, void 
    * version).
    */
 
-  typedef void (*cxa_throw_func)(void *, std::type_info *, void (*)(void *));
+  typedef void (*cxa_throw_func)(void *, std::type_info *, void (*)(void *)) __attribute__((noreturn));
   static dispatch_once_t predicate = 0;
   static cxa_throw_func __original__cxa_throw = nullptr;
   static const void **__real_objc_ehtype_vtable = nullptr;


### PR DESCRIPTION
The previous macro `LIBCXXABI_NORETURN` got renamed to `_ LIBCXXABI_NORETURN` but each version will only build in either Xcode 8 or 9.
This commit adds the slightly more verbose version of the attribute and the actual value both macros resolved to.