### PR TITLE
Add missing spaces to MSDistribute's log message.

### DIFF
--- a/MobileCenterDistribute/MobileCenterDistribute/MSDistribute.m
+++ b/MobileCenterDistribute/MobileCenterDistribute/MSDistribute.m
@@ -360,8 +360,8 @@ static NSString *const kMSUpdateTokenURLInvalidErrorDescFormat = @"Invalid updat
     MSLogDebug(
         [MSDistribute logTag],
         @"Distribute won't check if a new release is available because of one of the following reasons: 1. A debugger "
-         "is attached. 2. You are running the debug configuration. 3. The app is running in a non-adhoc environment."
-         "Detach the debugger and restart the app and/or run the app with the release configuration to enable the"
+         "is attached. 2. You are running the debug configuration. 3. The app is running in a non-adhoc environment. "
+         "Detach the debugger and restart the app and/or run the app with the release configuration to enable the "
          "feature.");
   }
 }


### PR DESCRIPTION
This is intended for post 0.10.0 release