### PR TITLE
Remove channel dependency from services

### DIFF
--- a/MobileCenter/MobileCenter.xcodeproj/project.pbxproj
+++ b/MobileCenter/MobileCenter.xcodeproj/project.pbxproj
@@ -702,13 +702,13 @@
 				E84B8E2C1D2351DB006FD231 /* MSLogManagerDefault.h */,
 				E84B8E2D1D2351DB006FD231 /* MSLogManagerDefault.m */,
 				04FD126E1E415697007ABFE7 /* MSLogManagerDefaultPrivate.h */,
+				E8AEE9811D5970A400C0FF6C /* MSLogManagerDelegate.h */,
 				6E0684651D36BCD500A8CC6C /* MSChannel.h */,
 				382CFCF01EC3817B003FE40B /* MSChannelDefaultPrivate.h */,
 				6E0684611D36BC8D00A8CC6C /* MSChannelDefault.h */,
 				6E0684621D36BC8D00A8CC6C /* MSChannelDefault.m */,
 				6EF628F21D371B1600CAFF64 /* MSChannelConfiguration.h */,
 				6EF628F31D371B1600CAFF64 /* MSChannelConfiguration.m */,
-				E8AEE9811D5970A400C0FF6C /* MSLogManagerDelegate.h */,
 				5949380E604D45340244FEF1 /* MSChannelDelegate.h */,
 			);
 			path = Channel;

--- a/MobileCenter/MobileCenter/Internals/Channel/MSChannelDelegate.h
+++ b/MobileCenter/MobileCenter/Internals/Channel/MSChannelDelegate.h
@@ -1,8 +1,9 @@
 #import <Foundation/Foundation.h>
+
 #import "MSChannel.h"
 
-@class MSLogWithProperties;
 @class MSLog;
+@class MSLogWithProperties;
 
 @protocol MSChannelDelegate <NSObject>
 
@@ -10,6 +11,7 @@
 
 /**
  * Callback method that will be called before each log will be send to the server.
+ *
  * @param channel Instance of MSChannel.
  * @param log The log to be sent.
  */
@@ -17,6 +19,7 @@
 
 /**
  * Callback method that will be called in case the SDK was able to send a log.
+ *
  * @param channel Instance of MSChannel.
  * @param log The log to be sent.
  */
@@ -24,6 +27,7 @@
 
 /**
  * Callback method that will be called in case the SDK was unable to send a log.
+ *
  * @param channel Instance of MSChannel.
  * @param log The log to be sent.
  * @param error The error that occured.

--- a/MobileCenter/MobileCenter/Internals/Channel/MSLogManager.h
+++ b/MobileCenter/MobileCenter/Internals/Channel/MSLogManager.h
@@ -1,4 +1,5 @@
 #import <Foundation/Foundation.h>
+
 #import "MSChannelConfiguration.h"
 #import "MSEnable.h"
 #import "MSLog.h"
@@ -61,22 +62,6 @@ NS_ASSUME_NONNULL_BEGIN
  *  @param groupId A groupId to enable/disable.
  */
 - (void)setEnabled:(BOOL)isEnabled andDeleteDataOnDisabled:(BOOL)deleteData forGroupId:(NSString *)groupId;
-
-/**
- * Add a delegate to each channel that has a certain priority.
- *
- * @param channelDelegate A delegate for the channel.
- * @param groupId The groupId of a channel.
- */
-- (void)addChannelDelegate:(id<MSChannelDelegate>)channelDelegate forGroupId:(NSString *)groupId;
-
-/**
- * Remove a delegate to each channel that has a certain priority.
- *
- * @param channelDelegate A delegate for the channel.
- * @param groupId The groupId of a channel.
- */
-- (void)removeChannelDelegate:(id<MSChannelDelegate>)channelDelegate forGroupId:(NSString *)groupId;
 
 /**
  * Suspend log manager, logs will not be sent but still stored.

--- a/MobileCenter/MobileCenter/Internals/Channel/MSLogManagerDefault.h
+++ b/MobileCenter/MobileCenter/Internals/Channel/MSLogManagerDefault.h
@@ -34,6 +34,11 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithAppSecret:(NSString *)appSecret installId:(NSUUID *)installId logUrl:(NSString *)logUrl;
 
 /**
+ * A boolean value set to YES if this instance is enabled or NO otherwise.
+ */
+@property BOOL enabled;
+
+/**
  * Hash table of log manager delegate.
  */
 @property(nonatomic) NSHashTable<id<MSLogManagerDelegate>> *delegates;

--- a/MobileCenter/MobileCenter/Internals/Channel/MSLogManagerDefault.m
+++ b/MobileCenter/MobileCenter/Internals/Channel/MSLogManagerDefault.m
@@ -86,11 +86,9 @@ static char *const MSlogsDispatchQueue = "com.microsoft.azure.mobile.mobilecente
 
                               /*
                                * If the delegate doesn't have groupId implementation, it assumes that the delegate is
-                               * interested in all kinds of logs.
+                               * interested in all kinds of logs. Otherwise, compare groupId.
                                */
                               if (![delegate respondsToSelector:@selector(groupId)] ||
-
-                                  // If the delegate has groupId implementation, compare groupId.
                                   [[delegate groupId] isEqualToString:[channel.configuration groupId]]) {
                                 [delegate willSendLog:log];
                               }
@@ -103,11 +101,9 @@ static char *const MSlogsDispatchQueue = "com.microsoft.azure.mobile.mobilecente
 
                               /*
                                * If the delegate doesn't have groupId implementation, it assumes that the delegate is
-                               * interested in all kinds of logs.
+                               * interested in all kinds of logs. Otherwise, compare groupId.
                                */
                               if (![delegate respondsToSelector:@selector(groupId)] ||
-
-                                  // If the delegate has groupId implementation, compare groupId.
                                   [[delegate groupId] isEqualToString:[channel.configuration groupId]]) {
                                 [delegate didSucceedSendingLog:log];
                               }
@@ -120,11 +116,9 @@ static char *const MSlogsDispatchQueue = "com.microsoft.azure.mobile.mobilecente
 
                               /*
                                * If the delegate doesn't have groupId implementation, it assumes that the delegate is
-                               * interested in all kinds of logs.
+                               * interested in all kinds of logs. Otherwise, compare groupId.
                                */
                               if (![delegate respondsToSelector:@selector(groupId)] ||
-
-                                  // If the delegate has groupId implementation, compare groupId.
                                   [[delegate groupId] isEqualToString:[channel.configuration groupId]]) {
                                 [delegate didFailSendingLog:log withError:error];
                               }

--- a/MobileCenter/MobileCenter/Internals/Channel/MSLogManagerDefault.m
+++ b/MobileCenter/MobileCenter/Internals/Channel/MSLogManagerDefault.m
@@ -1,4 +1,5 @@
 #import "MSChannelDefault.h"
+#import "MSChannelDelegate.h"
 #import "MSFileStorage.h"
 #import "MSHttpSender.h"
 #import "MSIngestionSender.h"
@@ -12,7 +13,7 @@ static char *const MSlogsDispatchQueue = "com.microsoft.azure.mobile.mobilecente
 /**
  * Private declaration of the log manager.
  */
-@interface MSLogManagerDefault ()
+@interface MSLogManagerDefault (MSChannelDelegate)
 
 @end
 
@@ -48,6 +49,7 @@ static char *const MSlogsDispatchQueue = "com.microsoft.azure.mobile.mobilecente
                                                storage:self.storage
                                          configuration:configuration
                                      logsDispatchQueue:self.logsDispatchQueue];
+    [channel addDelegate:(id<MSChannelDelegate>)self];
     self.channels[configuration.groupId] = channel;
   }
 }

--- a/MobileCenter/MobileCenter/Internals/Channel/MSLogManagerDefault.m
+++ b/MobileCenter/MobileCenter/Internals/Channel/MSLogManagerDefault.m
@@ -83,7 +83,15 @@ static char *const MSlogsDispatchQueue = "com.microsoft.azure.mobile.mobilecente
 - (void)channel:(id<MSChannel>)channel willSendLog:(id<MSLog>)log {
   [self enumerateDelegatesForSelector:@selector(willSendLog:)
                             withBlock:^(id<MSLogManagerDelegate> delegate) {
-                              if ([[delegate groupId] isEqualToString:[channel.configuration groupId]]) {
+
+                              /*
+                               * If the delegate doesn't have groupId implementation, it assumes that the delegate is
+                               * interested in all kinds of logs.
+                               */
+                              if (![delegate respondsToSelector:@selector(groupId)] ||
+
+                                  // If the delegate has groupId implementation, compare groupId.
+                                  [[delegate groupId] isEqualToString:[channel.configuration groupId]]) {
                                 [delegate willSendLog:log];
                               }
                             }];
@@ -92,7 +100,15 @@ static char *const MSlogsDispatchQueue = "com.microsoft.azure.mobile.mobilecente
 - (void)channel:(id<MSChannel>)channel didSucceedSendingLog:(id<MSLog>)log {
   [self enumerateDelegatesForSelector:@selector(didSucceedSendingLog:)
                             withBlock:^(id<MSLogManagerDelegate> delegate) {
-                              if ([[delegate groupId] isEqualToString:[channel.configuration groupId]]) {
+
+                              /*
+                               * If the delegate doesn't have groupId implementation, it assumes that the delegate is
+                               * interested in all kinds of logs.
+                               */
+                              if (![delegate respondsToSelector:@selector(groupId)] ||
+
+                                  // If the delegate has groupId implementation, compare groupId.
+                                  [[delegate groupId] isEqualToString:[channel.configuration groupId]]) {
                                 [delegate didSucceedSendingLog:log];
                               }
                             }];
@@ -101,7 +117,15 @@ static char *const MSlogsDispatchQueue = "com.microsoft.azure.mobile.mobilecente
 - (void)channel:(id<MSChannel>)channel didFailSendingLog:(id<MSLog>)log withError:(NSError *)error {
   [self enumerateDelegatesForSelector:@selector(didFailSendingLog:withError:)
                             withBlock:^(id<MSLogManagerDelegate> delegate) {
-                              if ([[delegate groupId] isEqualToString:[channel.configuration groupId]]) {
+
+                              /*
+                               * If the delegate doesn't have groupId implementation, it assumes that the delegate is
+                               * interested in all kinds of logs.
+                               */
+                              if (![delegate respondsToSelector:@selector(groupId)] ||
+
+                                  // If the delegate has groupId implementation, compare groupId.
+                                  [[delegate groupId] isEqualToString:[channel.configuration groupId]]) {
                                 [delegate didFailSendingLog:log withError:error];
                               }
                             }];

--- a/MobileCenter/MobileCenter/Internals/Channel/MSLogManagerDelegate.h
+++ b/MobileCenter/MobileCenter/Internals/Channel/MSLogManagerDelegate.h
@@ -47,7 +47,7 @@
 - (void)onFailedPersistingLog:(id<MSLog>)log withInternalId:(NSString *)internalId;
 
 /**
- * Callback method that will be called before each log will be send to the server.
+ * Callback method that will be called before each log will be sent to the server.
  *
  * @param log The log to be sent.
  */

--- a/MobileCenter/MobileCenter/Internals/Channel/MSLogManagerDelegate.h
+++ b/MobileCenter/MobileCenter/Internals/Channel/MSLogManagerDelegate.h
@@ -1,15 +1,18 @@
 #import <Foundation/Foundation.h>
-#import "MSConstants+Internal.h"
 
+#import "MSConstants+Internal.h"
+#import "MSLog.h"
+
+// TODO: We need to pass a sender instance in delegate methods or changing method name with a prefix of sender.
 @protocol MSLogManagerDelegate <NSObject>
 
 @optional
 
 /**
- *  A callback that is called when a log has been enqueued, before a log has been forwarded to persistence, etc.
+ * A callback that is called when a log has been enqueued, before a log has been forwarded to persistence, etc.
  *
- *  @param log The log.
- *  @param internalId An internal Id that can be used to keep track of logs.
+ * @param log The log.
+ * @param internalId An internal Id that can be used to keep track of logs.
  */
 - (void)onEnqueuingLog:(id<MSLog>)log withInternalId:(NSString *)internalId;
 
@@ -17,30 +20,59 @@
  * Callback that is called when a log has been persisted successfully. This was introduced to implement the
  * log buffer for Crashes.
  *
- *  @param log The log.
- *  @param internalId An internal Id that can be used to keep track of logs.
+ * @param log The log.
+ * @param internalId An internal Id that can be used to keep track of logs.
  *
- *  @discussion We had some discussion about the naming of the method. To match the
- *  onEnqueueingLog:withInternalId (@see onEnqueueingLog:withInternalId) callback, it should
- *  also use `enqueuing` in it's signature, yet, as of now, it indicates successful persistence of a log. This
- *  method's name might change in the future to make a distinction between a successfully enqueued log and a persisted
- *  log.
+ * @discussion We had some discussion about the naming of the method. To match the
+ * onEnqueueingLog:withInternalId (@see onEnqueueingLog:withInternalId) callback, it should
+ * also use `enqueuing` in it's signature, yet, as of now, it indicates successful persistence of a log. This
+ * method's name might change in the future to make a distinction between a successfully enqueued log and a persisted
+ * log.
  */
 - (void)onFinishedPersistingLog:(id<MSLog>)log withInternalId:(NSString *)internalId;
 
 /**
- *  Callback that is called when persisting a log has failed, meaning it has not been saved to disk because the log was
- *  empty. This was introduced to implement the log buffer for Crashes.
+ * Callback that is called when persisting a log has failed, meaning it has not been saved to disk because the log was
+ * empty. This was introduced to implement the log buffer for Crashes.
  *
- *  @param log The log.
- *  @param internalId An internal Id that can be used to keep track of logs.
+ * @param log The log.
+ * @param internalId An internal Id that can be used to keep track of logs.
  *
- *  @discussion We had some discussion about the naming of the method. To match the
- *  onEnqueueingLog:withInternalId (@see onEnqueueingLog:withInternalId) callback, it should
- *  also use `enqueuing` in it's signature, yet, as of now, it indicates successful persistence of a log. This
- *  method's name might change in the future to make a distinction between a successfully enqueued log and a persisted
- *  log.
+ * @discussion We had some discussion about the naming of the method. To match the
+ * onEnqueueingLog:withInternalId (@see onEnqueueingLog:withInternalId) callback, it should
+ * also use `enqueuing` in it's signature, yet, as of now, it indicates successful persistence of a log. This
+ * method's name might change in the future to make a distinction between a successfully enqueued log and a persisted
+ * log.
  */
 - (void)onFailedPersistingLog:(id<MSLog>)log withInternalId:(NSString *)internalId;
+
+/**
+ * Callback method that will be called before each log will be send to the server.
+ *
+ * @param log The log to be sent.
+ */
+- (void)willSendLog:(id<MSLog>)log;
+
+/**
+ * Callback method that will be called in case the SDK was able to send a log.
+ *
+ * @param log The log to be sent.
+ */
+- (void)didSucceedSendingLog:(id<MSLog>)log;
+
+/**
+ * Callback method that will be called in case the SDK was unable to send a log.
+ *
+ * @param log The log to be sent.
+ * @param error The error that occured.
+ */
+- (void)didFailSendingLog:(id<MSLog>)log withError:(NSError *)error;
+
+/**
+ * Get service unique key for storage purpose.
+ *
+ * @return A group ID of the service.
+ */
+- (NSString *)groupId;
 
 @end

--- a/MobileCenter/MobileCenter/Internals/Channel/MSLogManagerDelegate.h
+++ b/MobileCenter/MobileCenter/Internals/Channel/MSLogManagerDelegate.h
@@ -69,9 +69,9 @@
 - (void)didFailSendingLog:(id<MSLog>)log withError:(NSError *)error;
 
 /**
- * Get service unique key for storage purpose.
+ * Get a unique identifier for processing logs.
  *
- * @return A group ID of the service.
+ * @return A group ID for the logs.
  */
 - (NSString *)groupId;
 

--- a/MobileCenter/MobileCenterTests/MSAppDelegateForwarderTests.m
+++ b/MobileCenter/MobileCenterTests/MSAppDelegateForwarderTests.m
@@ -283,7 +283,7 @@
                                                       annotation:expectedAnnotation];
 
   // Then
-  assertThatInt(MSAppDelegateForwarder.delegates.count, equalToInt(0));
+  assertThatUnsignedLong(MSAppDelegateForwarder.delegates.count, equalToUnsignedLong(0));
   assertThatBool(returnedValue, is(@(expectedReturnedValue)));
   [self waitForExpectations:@[ originalCalledExpectation ] timeout:1];
 }

--- a/MobileCenter/MobileCenterTests/MSLogManagerDefaultTests.m
+++ b/MobileCenter/MobileCenterTests/MSLogManagerDefaultTests.m
@@ -61,8 +61,8 @@
   assertThat(channel, notNilValue());
   XCTAssertTrue(channel.configuration.priority == priority);
   assertThatFloat(channel.configuration.flushInterval, equalToFloat(flushInterval));
-  assertThatUnsignedInt(channel.configuration.batchSizeLimit, equalToUnsignedInteger(batchSizeLimit));
-  assertThatUnsignedInt(channel.configuration.pendingBatchesLimit, equalToUnsignedInteger(pendingBatchesLimit));
+  assertThatUnsignedLong(channel.configuration.batchSizeLimit, equalToUnsignedLong(batchSizeLimit));
+  assertThatUnsignedLong(channel.configuration.pendingBatchesLimit, equalToUnsignedLong(pendingBatchesLimit));
 }
 
 - (void)testProcessingLogWillTriggerOnProcessingCall {

--- a/MobileCenterAnalytics/MobileCenterAnalytics/Internals/MSAnalyticsInternal.h
+++ b/MobileCenterAnalytics/MobileCenterAnalytics/Internals/MSAnalyticsInternal.h
@@ -1,11 +1,11 @@
 #import "MSAnalytics.h"
 #import "MSServiceInternal.h"
 #import "MSAnalyticsDelegate.h"
-#import "MSChannelDelegate.h"
+#import "MSLogManagerDelegate.h"
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface MSAnalytics () <MSServiceInternal, MSChannelDelegate>
+@interface MSAnalytics () <MSServiceInternal, MSLogManagerDelegate>
 
 // Temporarily hiding tracking page feature.
 /**

--- a/MobileCenterAnalytics/MobileCenterAnalytics/MSAnalytics.m
+++ b/MobileCenterAnalytics/MobileCenterAnalytics/MSAnalytics.m
@@ -87,11 +87,9 @@ static const int maxPropertyValueLength = 64;
     // Start session tracker.
     [self.sessionTracker start];
 
-    // Add delegate to log manager.
+    // Add delegates to log manager.
     [self.logManager addDelegate:self.sessionTracker];
-
-    // Set self as delegate of analytics channel.
-    [self.logManager addChannelDelegate:self forGroupId:self.groupId];
+    [self.logManager addDelegate:self];
 
     // Report current page while auto page tracking is on.
     if (self.autoPageTrackingEnabled) {
@@ -107,7 +105,7 @@ static const int maxPropertyValueLength = 64;
     MSLogInfo([MSAnalytics logTag], @"Analytics service has been enabled.");
   } else {
     [self.logManager removeDelegate:self.sessionTracker];
-    [self.logManager removeChannelDelegate:self forGroupId:self.groupId];
+    [self.logManager removeDelegate:self];
     [self.sessionTracker stop];
     [self.sessionTracker clearSessions];
     MSLogInfo([MSAnalytics logTag], @"Analytics service has been disabled.");
@@ -307,10 +305,9 @@ static const int maxPropertyValueLength = 64;
   [[self sharedInstance] setDelegate:delegate];
 }
 
-#pragma mark - MSChannelDelegate
+#pragma mark - MSLogManagerDelegate
 
-- (void)channel:(id<MSChannel>)channel willSendLog:(id<MSLog>)log {
-  (void)channel;
+- (void)willSendLog:(id<MSLog>)log {
   if (!self.delegate) {
     return;
   }
@@ -326,8 +323,7 @@ static const int maxPropertyValueLength = 64;
   }
 }
 
-- (void)channel:(id<MSChannel>)channel didSucceedSendingLog:(id<MSLog>)log {
-  (void)channel;
+- (void)didSucceedSendingLog:(id<MSLog>)log {
   if (!self.delegate) {
     return;
   }
@@ -343,8 +339,7 @@ static const int maxPropertyValueLength = 64;
   }
 }
 
-- (void)channel:(id<MSChannel>)channel didFailSendingLog:(id<MSLog>)log withError:(NSError *)error {
-  (void)channel;
+- (void)didFailSendingLog:(id<MSLog>)log withError:(NSError *)error {
   if (!self.delegate) {
     return;
   }

--- a/MobileCenterAnalytics/MobileCenterAnalyticsTests/MSAnalyticsTests.m
+++ b/MobileCenterAnalytics/MobileCenterAnalyticsTests/MSAnalyticsTests.m
@@ -204,9 +204,9 @@ static NSString *const kMSAnalyticsServiceName = @"Analytics";
   self.didFailSendingEventLogWasCalled = false;
   [[MSAnalytics sharedInstance] setDelegate:self];
   MSEventLog *eventLog = [MSEventLog new];
-  [[MSAnalytics sharedInstance] channel:nil willSendLog:eventLog];
-  [[MSAnalytics sharedInstance] channel:nil didSucceedSendingLog:eventLog];
-  [[MSAnalytics sharedInstance] channel:nil didFailSendingLog:eventLog withError:nil];
+  [[MSAnalytics sharedInstance] willSendLog:eventLog];
+  [[MSAnalytics sharedInstance] didSucceedSendingLog:eventLog];
+  [[MSAnalytics sharedInstance] didFailSendingLog:eventLog withError:nil];
 
   XCTAssertTrue(self.willSendEventLogWasCalled);
   XCTAssertTrue(self.didSucceedSendingEventLogWasCalled);

--- a/MobileCenterCrashes/MobileCenterCrashes/Internals/MSCrashesPrivate.h
+++ b/MobileCenterCrashes/MobileCenterCrashes/Internals/MSCrashesPrivate.h
@@ -1,9 +1,9 @@
-#import "MSCrashes.h"
 #import <CrashReporter/CrashReporter.h>
-
 #import <string>
 #import <array>
 #import <unordered_map>
+
+#import "MSCrashes.h"
 
 @class MSMPLCrashReporter;
 
@@ -39,7 +39,7 @@ const int ms_crashes_log_buffer_size = 60;
  */
 extern std::array<MSCrashesBufferedLog, ms_crashes_log_buffer_size> msCrashesLogBuffer;
 
-@interface MSCrashes () <MSChannelDelegate, MSLogManagerDelegate>
+@interface MSCrashes () <MSLogManagerDelegate>
 
 /**
  * Prototype of a callback function used to execute additional user code. Called

--- a/MobileCenterCrashes/MobileCenterCrashes/MSCrashes.mm
+++ b/MobileCenterCrashes/MobileCenterCrashes/MSCrashes.mm
@@ -288,9 +288,6 @@ __attribute__((noreturn)) static void uncaught_cxx_exception_handler(const MSCra
     // Get persisted crash reports.
     self.crashFiles = [self persistedCrashReports];
 
-    // Set self as delegate of crashes' channel.
-    [self.logManager addChannelDelegate:self forGroupId:self.groupId];
-
     // Process PLCrashReports, this will format the PLCrashReport into our schema and then trigger sending.
     // This mostly happens on the start of the service.
     if (self.crashFiles.count > 0) {
@@ -314,11 +311,6 @@ __attribute__((noreturn)) static void uncaught_cxx_exception_handler(const MSCra
     [self emptyLogBufferFiles];
     [self removeAnalyzerFile];
     [self.plCrashReporter purgePendingCrashReport];
-
-    // Remove as ChannelDelegate from LogManager
-    [self.logManager removeChannelDelegate:self forGroupId:self.groupId];
-    [self.logManager removeChannelDelegate:self forGroupId:self.groupId];
-    [self.logManager removeChannelDelegate:self forGroupId:self.groupId];
     MSLogInfo([MSCrashes logTag], @"Crashes service has been disabled.");
   }
 }
@@ -474,10 +466,7 @@ __attribute__((noreturn)) static void uncaught_cxx_exception_handler(const MSCra
   }
 }
 
-#pragma mark - MSChannelDelegate
-
-- (void)channel:(id<MSChannel>)channel willSendLog:(id<MSLog>)log {
-  (void)channel;
+- (void)willSendLog:(id<MSLog>)log {
   id<MSCrashesDelegate> strongDelegate = self.delegate;
   if (strongDelegate && [strongDelegate respondsToSelector:@selector(crashes:willSendErrorReport:)]) {
     NSObject *logObject = static_cast<NSObject *>(log);
@@ -489,8 +478,7 @@ __attribute__((noreturn)) static void uncaught_cxx_exception_handler(const MSCra
   }
 }
 
-- (void)channel:(id<MSChannel>)channel didSucceedSendingLog:(id<MSLog>)log {
-  (void)channel;
+- (void)didSucceedSendingLog:(id<MSLog>)log {
   id<MSCrashesDelegate> strongDelegate = self.delegate;
   if (strongDelegate && [strongDelegate respondsToSelector:@selector(crashes:didSucceedSendingErrorReport:)]) {
     NSObject *logObject = static_cast<NSObject *>(log);
@@ -502,8 +490,7 @@ __attribute__((noreturn)) static void uncaught_cxx_exception_handler(const MSCra
   }
 }
 
-- (void)channel:(id<MSChannel>)channel didFailSendingLog:(id<MSLog>)log withError:(NSError *)error {
-  (void)channel;
+- (void)didFailSendingLog:(id<MSLog>)log withError:(NSError *)error {
   id<MSCrashesDelegate> strongDelegate = self.delegate;
   if (strongDelegate && [strongDelegate respondsToSelector:@selector(crashes:didFailSendingErrorReport:withError:)]) {
     NSObject *logObject = static_cast<NSObject *>(log);

--- a/MobileCenterCrashes/MobileCenterCrashesTests/MSCrashesTests.mm
+++ b/MobileCenterCrashes/MobileCenterCrashesTests/MSCrashesTests.mm
@@ -130,9 +130,9 @@ static unsigned int kMaxAttachmentsPerCrashReport = 2;
   // When
   [[MSCrashes sharedInstance] setDelegate:self];
   MSAppleErrorLog *errorLog = [MSAppleErrorLog new];
-  [[MSCrashes sharedInstance] channel:nil willSendLog:errorLog];
-  [[MSCrashes sharedInstance] channel:nil didSucceedSendingLog:errorLog];
-  [[MSCrashes sharedInstance] channel:nil didFailSendingLog:errorLog withError:nil];
+  [[MSCrashes sharedInstance] willSendLog:errorLog];
+  [[MSCrashes sharedInstance] didSucceedSendingLog:errorLog];
+  [[MSCrashes sharedInstance] didFailSendingLog:errorLog withError:nil];
   [[MSCrashes sharedInstance] shouldProcessErrorReport:nil];
 
   // Then

--- a/MobileCenterCrashes/MobileCenterCrashesTests/MSCrashesTests.mm
+++ b/MobileCenterCrashes/MobileCenterCrashesTests/MSCrashesTests.mm
@@ -4,13 +4,18 @@
 #import <XCTest/XCTest.h>
 
 #import "MSAppleErrorLog.h"
+#import "MSChannelDefault.h"
 #import "MSCrashesDelegate.h"
 #import "MSCrashesInternal.h"
 #import "MSCrashesPrivate.h"
 #import "MSCrashesTestUtil.h"
 #import "MSCrashesUtil.h"
 #import "MSErrorAttachmentLog.h"
+#import "MSErrorLogFormatter.h"
 #import "MSException.h"
+#import "MSLogManagerDefault.h"
+#import "MSMobileCenter.h"
+#import "MSMobileCenterInternal.h"
 #import "MSMockCrashesDelegate.h"
 #import "MSServiceAbstractPrivate.h"
 #import "MSServiceAbstractProtected.h"
@@ -29,22 +34,11 @@ static unsigned int kMaxAttachmentsPerCrashReport = 2;
 
 - (void)startCrashProcessing;
 
-- (void)channel:(id<MSChannel>)channel willSendLog:(id<MSLog>)log;
-
-- (void)channel:(id<MSChannel>)channel didSucceedSendingLog:(id<MSLog>)log;
-
-- (void)channel:(id<MSChannel>)channel didFailSendingLog:(id<MSLog>)log withError:(NSError *)error;
-
 @end
 
 @interface MSCrashesTests : XCTestCase <MSCrashesDelegate>
 
 @property(nonatomic) MSCrashes *sut;
-
-@property BOOL shouldProcessErrorReportCalled;
-@property BOOL willSendErrorReportCalled;
-@property BOOL didSucceedSendingErrorReportCalled;
-@property BOOL didFailSendingErrorReportCalled;
 
 @end
 
@@ -122,24 +116,37 @@ static unsigned int kMaxAttachmentsPerCrashReport = 2;
 - (void)testDelegateMethodsAreCalled {
 
   // If
-  self.shouldProcessErrorReportCalled = false;
-  self.willSendErrorReportCalled = false;
-  self.didSucceedSendingErrorReportCalled = false;
-  self.didFailSendingErrorReportCalled = false;
+  NSString *groupId = [[MSCrashes sharedInstance] groupId];
+  id<MSCrashesDelegate> delegateMock = OCMProtocolMock(@protocol(MSCrashesDelegate));
+  [MSMobileCenter sharedInstance].sdkConfigured = NO;
+  [MSMobileCenter start:kMSTestAppSecret withServices:@[ [MSCrashes class] ]];
+  NSMutableDictionary *channelsInLogManager =
+      (static_cast<MSLogManagerDefault *>([MSCrashes sharedInstance].logManager)).channels;
+  MSChannelDefault *channelMock = channelsInLogManager[groupId] = OCMPartialMock(channelsInLogManager[groupId]);
+  OCMStub([channelMock enqueueItem:[OCMArg any] withCompletion:[OCMArg any]]).andDo(^(NSInvocation *invocation) {
+    id<MSLog> log = nil;
+    [invocation getArgument:&log atIndex:2];
+    for (id<MSChannelDelegate> delegate in channelMock.delegates) {
+
+      // Call all channel delegate methods for testing.
+      [delegate channel:channelMock willSendLog:log];
+      [delegate channel:channelMock didSucceedSendingLog:log];
+      [delegate channel:channelMock didFailSendingLog:log withError:nil];
+    }
+  });
+  MSAppleErrorLog *errorLog = OCMClassMock([MSAppleErrorLog class]);
+  MSErrorReport *errorReport = OCMClassMock([MSErrorReport class]);
+  id errorLogFormatterMock = OCMClassMock([MSErrorLogFormatter class]);
+  OCMStub(ClassMethod([errorLogFormatterMock errorReportFromLog:errorLog])).andReturn(errorReport);
 
   // When
-  [[MSCrashes sharedInstance] setDelegate:self];
-  MSAppleErrorLog *errorLog = [MSAppleErrorLog new];
-  [[MSCrashes sharedInstance] willSendLog:errorLog];
-  [[MSCrashes sharedInstance] didSucceedSendingLog:errorLog];
-  [[MSCrashes sharedInstance] didFailSendingLog:errorLog withError:nil];
-  [[MSCrashes sharedInstance] shouldProcessErrorReport:nil];
+  [[MSCrashes sharedInstance] setDelegate:delegateMock];
+  [[MSCrashes sharedInstance].logManager processLog:errorLog forGroupId:groupId];
 
   // Then
-  XCTAssertTrue(self.shouldProcessErrorReportCalled);
-  XCTAssertTrue(self.willSendErrorReportCalled);
-  XCTAssertTrue(self.didSucceedSendingErrorReportCalled);
-  XCTAssertTrue(self.didFailSendingErrorReportCalled);
+  OCMVerify([delegateMock crashes:[MSCrashes sharedInstance] willSendErrorReport:errorReport]);
+  OCMVerify([delegateMock crashes:[MSCrashes sharedInstance] didSucceedSendingErrorReport:errorReport]);
+  OCMVerify([delegateMock crashes:[MSCrashes sharedInstance] didFailSendingErrorReport:errorReport withError:nil]);
 }
 
 - (void)testSettingUserConfirmationHandler {
@@ -529,32 +536,6 @@ static unsigned int kMaxAttachmentsPerCrashReport = 2;
   [[MSCrashes sharedInstance] startCrashProcessing];
 
   XCTAssertTrue(warningMessageHasBeenPrinted);
-}
-
-- (BOOL)crashes:(MSCrashes *)crashes shouldProcessErrorReport:(MSErrorReport *)errorReport {
-  (void)crashes;
-  (void)errorReport;
-  self.shouldProcessErrorReportCalled = true;
-  return YES;
-}
-
-- (void)crashes:(MSCrashes *)crashes willSendErrorReport:(MSErrorReport *)errorReport {
-  (void)crashes;
-  (void)errorReport;
-  self.willSendErrorReportCalled = true;
-}
-
-- (void)crashes:(MSCrashes *)crashes didSucceedSendingErrorReport:(MSErrorReport *)errorReport {
-  (void)crashes;
-  (void)errorReport;
-  self.didSucceedSendingErrorReportCalled = true;
-}
-
-- (void)crashes:(MSCrashes *)crashes didFailSendingErrorReport:(MSErrorReport *)errorReport withError:(NSError *)error {
-  (void)crashes;
-  (void)errorReport;
-  (void)error;
-  self.didFailSendingErrorReportCalled = true;
 }
 
 #pragma clang diagnostic push


### PR DESCRIPTION
MSAnalyticsDelegate has not been exposed so I don't need to hide the delegate.
Still we need to decouple the dependency of channel from services so I remove this dependency and all communication will go through log manager delegate.

This is re-implementation of #549 and reverting #566.