### PR TITLE
Fix warnings in demo applications

### DIFF
--- a/Puppet/Puppet/MSAnalyticsResultViewController.m
+++ b/Puppet/Puppet/MSAnalyticsResultViewController.m
@@ -49,7 +49,7 @@
   dispatch_async(dispatch_get_main_queue(), ^{
     id log = notification.object;
     self.eventNameLabel.text = [log eventName];
-    self.eventPropsLabel.text = [NSString stringWithFormat:@"%lu", [log properties].count];
+    self.eventPropsLabel.text = [NSString stringWithFormat:@"%tu", [log properties].count];
     self.didSendingEventLabel.text = kDidSendingEventText;
     [self reloadCells];
   });
@@ -59,7 +59,7 @@
   dispatch_async(dispatch_get_main_queue(), ^{
     id log = notification.object;
     self.eventNameLabel.text = [log eventName];
-    self.eventPropsLabel.text = [NSString stringWithFormat:@"%lu", [log properties].count];
+    self.eventPropsLabel.text = [NSString stringWithFormat:@"%tu", [log properties].count];
     self.didSentEventLabel.text = kDidSentEventText;
     [self reloadCells];
   });
@@ -69,7 +69,7 @@
   dispatch_async(dispatch_get_main_queue(), ^{
     id log = notification.object;
     self.eventNameLabel.text = [log eventName];
-    self.eventPropsLabel.text = [NSString stringWithFormat:@"%lu", [log properties].count];
+    self.eventPropsLabel.text = [NSString stringWithFormat:@"%tu", [log properties].count];
     self.didFailedToSendEventLabel.text = kDidFailedToSendEventText;
     [self reloadCells];
   });

--- a/Sasquatch/Sasquatch/MSCrashesViewController.swift
+++ b/Sasquatch/Sasquatch/MSCrashesViewController.swift
@@ -84,7 +84,7 @@ class MSCrashesViewController: UITableViewController, MobileCenterProtocol {
     let classList = objc_copyClassList(&count)
     MSCrash.removeAllCrashes()
     for i in 0..<Int(count){
-      let className = classList![i]!
+      let className: AnyClass = classList![i]!
       if class_getSuperclass(className) == MSCrash.self && className != MSCrash.self{
         MSCrash.register((className as! MSCrash.Type).init())
       }


### PR DESCRIPTION
When apps archiving it has PBXCp warning, but it is harmless. It occurs because building the application project attempts to strip the framework but it can’t since the framework is already codesigned. However the framework has already been stripped during it’s build. This step might be disabled by set "Strip Debug Symbols During Copy" to "No", but I'm really not sure that is right way: this might bloat app if it have other unsigned dependencies.