### PR TITLE
Revert "Use timestamp instead toffset"

### DIFF
--- a/MobileCenter/MobileCenter/Internals/Channel/MSLogManagerDefault.m
+++ b/MobileCenter/MobileCenter/Internals/Channel/MSLogManagerDefault.m
@@ -150,7 +150,7 @@ static char *const kMSlogsDispatchQueue = "com.microsoft.azure.mobile.mobilecent
                             }];
 
   // Set common log info.
-  log.timestamp = [NSDate date];
+  log.toffset = [NSNumber numberWithLongLong:(long long)([MSUtility nowInMilliseconds])];
 
   // Only add device info in case the log doesn't have one. In case the log is restored after a crash or for crashes,
   // We don't want the device information to be updated but want the old one preserved.

--- a/MobileCenter/MobileCenter/Internals/Device/MSDeviceHistoryInfo.h
+++ b/MobileCenter/MobileCenter/Internals/Device/MSDeviceHistoryInfo.h
@@ -8,15 +8,15 @@
 @interface MSDeviceHistoryInfo : NSObject <NSCoding>
 
 /**
- * The moment in time for the device history.
+ * The tOffset that indicates the moment in time for the device history.
  */
-@property (nonatomic) NSDate *timestamp;
+@property (nonatomic) NSNumber *tOffset;
 
 /**
  * Instance of MSDevice.
  */
 @property (nonatomic) MSDevice *device;
 
-- (instancetype)initWithTimestamp:(NSDate *)timestamp andDevice:(MSDevice *)device;
+- (instancetype)initWithTOffset:(NSNumber *)tOffset andDevice:(MSDevice *)device;
 
 @end

--- a/MobileCenter/MobileCenter/Internals/Device/MSDeviceHistoryInfo.m
+++ b/MobileCenter/MobileCenter/Internals/Device/MSDeviceHistoryInfo.m
@@ -1,13 +1,13 @@
 #import "MSDeviceHistoryInfo.h"
 
 static NSString *const kMSDeviceKey = @"deviceKey";
-static NSString *const kMSTimestampKey = @"timestampKey";
+static NSString *const kMSToffsetKey = @"toffsetKey";
 
 @implementation MSDeviceHistoryInfo
 
-- (instancetype)initWithTimestamp:(NSDate *)timestamp andDevice:(MSDevice *)device {
+- (instancetype)initWithTOffset:(NSNumber *)tOffset andDevice:(MSDevice *)device {
   if ((self = [super init])) {
-    _timestamp = timestamp;
+    _tOffset = tOffset;
     _device = device;
   }
   return self;
@@ -18,7 +18,7 @@ static NSString *const kMSTimestampKey = @"timestampKey";
 - (instancetype)initWithCoder:(NSCoder *)coder {
   self = [super init];
   if (self) {
-    self.timestamp = [coder decodeObjectForKey:kMSTimestampKey];
+    self.tOffset = [coder decodeObjectForKey:kMSToffsetKey];
     self.device = [coder decodeObjectForKey:kMSDeviceKey];
   }
 
@@ -26,7 +26,7 @@ static NSString *const kMSTimestampKey = @"timestampKey";
 }
 
 - (void)encodeWithCoder:(NSCoder *)coder {
-  [coder encodeObject:self.timestamp forKey:kMSTimestampKey];
+  [coder encodeObject:self.tOffset forKey:kMSToffsetKey];
   [coder encodeObject:self.device forKey:kMSDeviceKey];
 }
 

--- a/MobileCenter/MobileCenter/Internals/Device/MSDeviceTrackerPrivate.h
+++ b/MobileCenter/MobileCenter/Internals/Device/MSDeviceTrackerPrivate.h
@@ -152,13 +152,13 @@ static NSString *const kMSPastDevicesKey = @"pastDevicesKey";
 /**
  * Return a device from the history of past devices. This will be used e.g. for Crashes after relaunch.
  *
- * @param timestamp Timestamp that will be used to find a matching MSDevice in history.
+ * @param toffset Offset that will be used to find a matching MSDevice in history.
  *
- * @return Instance of MSDevice that's closest to timestamp.
+ * @return Instance of MSDevice that's closest to tOffset.
  *
- * @discussion If we cannot find a device that's within the range of the timestamp, the latest device from history will be
+ * @discussion If we cannot find a device that's within the range of the tOffset, the latest device from history will be
  * returned. If there is no history, we return the current MSDevice.
  */
-- (MSDevice *)deviceForTimestamp:(NSDate *)timestamp;
+- (MSDevice *)deviceForToffset:(NSNumber *)toffset;
 
 @end

--- a/MobileCenter/MobileCenter/Internals/Model/MSAbstractLog.m
+++ b/MobileCenter/MobileCenter/Internals/Model/MSAbstractLog.m
@@ -5,14 +5,14 @@
 #import "MSUtility+Date.h"
 
 static NSString *const kMSSid = @"sid";
-static NSString *const kMSTimestamp = @"timestamp";
+static NSString *const kMSToffset = @"toffset";
 static NSString *const kMSDevice = @"device";
 static NSString *const kMSType = @"type";
 
 @implementation MSAbstractLog
 
 @synthesize type = _type;
-@synthesize timestamp = _timestamp;
+@synthesize toffset = _toffset;
 @synthesize sid = _sid;
 @synthesize device = _device;
 
@@ -22,8 +22,12 @@ static NSString *const kMSType = @"type";
   if (self.type) {
     dict[kMSType] = self.type;
   }
-  if (self.timestamp) {
-    dict[kMSTimestamp] = [MSUtility dateToISO8601:self.timestamp];
+  if (self.toffset) {
+
+    // Set the toffset relative to current time. The toffset needs to be up to date.
+    long long now = (long long)[MSUtility nowInMilliseconds];
+    long long relativeTime = now - [self.toffset longLongValue];
+    dict[kMSToffset] = @(relativeTime);
   }
   if (self.sid) {
     dict[kMSSid] = self.sid;
@@ -35,7 +39,7 @@ static NSString *const kMSType = @"type";
 }
 
 - (BOOL)isValid {
-  return self.type && self.timestamp && self.device && [self.device isValid];
+  return self.type && self.toffset && self.device && [self.device isValid];
 }
 
 - (BOOL)isEqual:(id)object {
@@ -44,7 +48,7 @@ static NSString *const kMSType = @"type";
   }
   MSAbstractLog *log = (MSAbstractLog *)object;
   return ((!self.type && !log.type) || [self.type isEqualToString:log.type]) &&
-         ((!self.timestamp && !log.timestamp) || [self.timestamp isEqualToDate:log.timestamp]) &&
+         ((!self.toffset && !log.toffset) || [self.toffset isEqualToNumber:log.toffset]) &&
          ((!self.sid && !log.sid) || [self.sid isEqualToString:log.sid]) &&
          ((!self.device && !log.device) || [self.device isEqual:log.device]);
 }
@@ -55,7 +59,7 @@ static NSString *const kMSType = @"type";
   self = [super init];
   if (self) {
     _type = [coder decodeObjectForKey:kMSType];
-    _timestamp = [coder decodeObjectForKey:kMSTimestamp];
+    _toffset = [coder decodeObjectForKey:kMSToffset];
     _sid = [coder decodeObjectForKey:kMSSid];
     _device = [coder decodeObjectForKey:kMSDevice];
   }
@@ -64,7 +68,7 @@ static NSString *const kMSType = @"type";
 
 - (void)encodeWithCoder:(NSCoder *)coder {
   [coder encodeObject:self.type forKey:kMSType];
-  [coder encodeObject:self.timestamp forKey:kMSTimestamp];
+  [coder encodeObject:self.toffset forKey:kMSToffset];
   [coder encodeObject:self.sid forKey:kMSSid];
   [coder encodeObject:self.device forKey:kMSDevice];
 }

--- a/MobileCenter/MobileCenter/Internals/Model/MSCustomPropertiesLog.m
+++ b/MobileCenter/MobileCenter/Internals/Model/MSCustomPropertiesLog.m
@@ -1,5 +1,4 @@
 #import "MSCustomPropertiesLog.h"
-#import "MSUtility+Date.h"
 
 static NSString *const kMSCustomProperties = @"custom_properties";
 static NSString *const kMSProperties = @"properties";
@@ -78,8 +77,15 @@ static NSString *const kMSPropertyTypeString = @"string";
       [property setObject:value forKey:kMSPropertyValue];
     }
   } else if ([value isKindOfClass:[NSDate class]]) {
+    static NSDateFormatter *dateFormatter = nil;
+    if (!dateFormatter) {
+      dateFormatter = [[NSDateFormatter alloc] init];
+      [dateFormatter setLocale:[NSLocale systemLocale]];
+      [dateFormatter setTimeZone:[NSTimeZone timeZoneWithAbbreviation: @"UTC"]];
+      [dateFormatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ss'Z'"];
+    }
     [property setObject:kMSPropertyTypeDateTime forKey:kMSPropertyType];
-    [property setObject:[MSUtility dateToISO8601:(NSDate *)value] forKey:kMSPropertyValue];
+    [property setObject:[dateFormatter stringFromDate:(NSDate *)value] forKey:kMSPropertyValue];
   } else if ([value isKindOfClass:[NSString class]]) {
     [property setObject:kMSPropertyTypeString forKey:kMSPropertyType];
     [property setObject:value forKey:kMSPropertyValue];

--- a/MobileCenter/MobileCenter/Internals/Model/MSLog.h
+++ b/MobileCenter/MobileCenter/Internals/Model/MSLog.h
@@ -10,9 +10,10 @@
 @property(nonatomic, copy) NSString *type;
 
 /**
- * Log timestamp.
+ * Corresponds to the number of milliseconds elapsed between the time the
+ * request is sent and the time the log is emitted.
  */
-@property(nonatomic) NSDate *timestamp;
+@property(nonatomic) NSNumber *toffset;
 
 /**
  * A session identifier is used to correlate logs together. A session is an abstract concept in the API and

--- a/MobileCenter/MobileCenter/Internals/Utils/MSUtility+Date.h
+++ b/MobileCenter/MobileCenter/Internals/Utils/MSUtility+Date.h
@@ -24,11 +24,4 @@ extern NSString *MSUtilityDateCategory;
  */
 + (NSTimeInterval)nowInMilliseconds;
 
-/**
- * Convert a date object to an ISO 8601 formatted string.
- *
- * @return an ISO 8601 string representation of the date.
- */
-+ (NSString *)dateToISO8601:(NSDate *)date;
-
 @end

--- a/MobileCenter/MobileCenter/Internals/Utils/MSUtility+Date.m
+++ b/MobileCenter/MobileCenter/Internals/Utils/MSUtility+Date.m
@@ -11,15 +11,4 @@ NSString *MSUtilityDateCategory;
     return ([[NSDate date] timeIntervalSince1970] * 1000);
 }
 
-+ (NSString *)dateToISO8601:(NSDate *)date {
-  static NSDateFormatter *dateFormatter = nil;
-  if (!dateFormatter) {
-    dateFormatter = [[NSDateFormatter alloc] init];
-    [dateFormatter setLocale:[NSLocale systemLocale]];
-    [dateFormatter setTimeZone:[NSTimeZone timeZoneWithAbbreviation: @"UTC"]];
-    [dateFormatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ss'Z'"];
-  }
-  return [dateFormatter stringFromDate:date];
-}
-
 @end

--- a/MobileCenter/MobileCenterTests/MSChannelDefaultTests.m
+++ b/MobileCenter/MobileCenterTests/MSChannelDefaultTests.m
@@ -149,7 +149,7 @@ static NSString *const kMSTestGroupId = @"GroupId";
                                  assertThat(logContainer.batchId, is(expectedBatchId));
                                  assertThat(logContainer.logs, is(@[ expectedLog ]));
                                  assertThatBool(sut.pendingBatchQueueFull, isFalse());
-                                 assertThatUnsignedLong(sut.pendingBatchIds.count, equalToUnsignedLong(0));
+                                 assertThatUnsignedInt(sut.pendingBatchIds.count, equalToInt(0));
                                  OCMVerifyAll(delegateMock);
                                  OCMVerifyAll(storageMock);
                                  if (error) {
@@ -238,7 +238,7 @@ static NSString *const kMSTestGroupId = @"GroupId";
                                  assertThat(logContainer.batchId, is(expectedBatchId));
                                  assertThat(logContainer.logs, is(@[ expectedLog ]));
                                  assertThatBool(sut.pendingBatchQueueFull, isFalse());
-                                 assertThatUnsignedLong(sut.pendingBatchIds.count, equalToUnsignedLong(0));
+                                 assertThatUnsignedInt(sut.pendingBatchIds.count, equalToInt(0));
                                  OCMVerifyAll(delegateMock);
                                  OCMVerifyAll(storageMock);
                                  if (error) {

--- a/MobileCenter/MobileCenterTests/MSCustomPropertiesLogTests.m
+++ b/MobileCenter/MobileCenterTests/MSCustomPropertiesLogTests.m
@@ -93,7 +93,7 @@
   // If
   self.sut.device = OCMClassMock([MSDevice class]);
   OCMStub([self.sut.device isValid]).andReturn(YES);
-  self.sut.timestamp = [NSDate dateWithTimeIntervalSince1970:42];
+  self.sut.toffset = @(3);
   self.sut.sid = @"1234567890";
   
   // When

--- a/MobileCenter/MobileCenterTests/MSDeviceHistoryInfoTests.m
+++ b/MobileCenter/MobileCenterTests/MSDeviceHistoryInfoTests.m
@@ -18,14 +18,13 @@
   XCTAssertNotNil(expected);
   
   // When
-  NSDate *timestamp = [NSDate dateWithTimeIntervalSince1970:42];
   MSDevice *aDevice = [MSDevice new];
-  expected = [[MSDeviceHistoryInfo alloc] initWithTimestamp:timestamp andDevice:aDevice];
+  expected = [[MSDeviceHistoryInfo alloc] initWithTOffset:@1 andDevice:aDevice];
   
   // Then
   XCTAssertNotNil(expected);
-  XCTAssertTrue([expected.timestamp isEqual:timestamp]);
   XCTAssertTrue([expected.device isEqual:aDevice]);
+  XCTAssertTrue([expected.tOffset isEqualToNumber:@1]);
 }
 
 @end

--- a/MobileCenter/MobileCenterTests/MSDeviceTrackerTests.m
+++ b/MobileCenter/MobileCenterTests/MSDeviceTrackerTests.m
@@ -415,7 +415,7 @@ static NSString *const kMSDeviceManufacturerTest = @"Apple";
   [tracker clearDevices];
 
   // When
-  MSDevice *actual = [tracker deviceForTimestamp:[NSDate dateWithTimeIntervalSince1970:1]];
+  MSDevice *actual = [tracker deviceForToffset:@1];
 
   // Then
   XCTAssertTrue([actual isEqual:tracker.device]);
@@ -429,13 +429,14 @@ static NSString *const kMSDeviceManufacturerTest = @"Apple";
   MSDevice *third = [tracker device];
 
   // When
-  actual = [tracker deviceForTimestamp:[NSDate dateWithTimeIntervalSince1970:1]];
+  actual = [tracker deviceForToffset:@1];
 
   // Then
   XCTAssertTrue([actual isEqual:first]);
 
   // When
-  actual = [tracker deviceForTimestamp:[NSDate date]];
+  NSNumber *now = [NSNumber numberWithLongLong:(long long)([MSUtility nowInMilliseconds])];
+  actual = [tracker deviceForToffset:now];
 
   // Then
   XCTAssertTrue([actual isEqual:third]);

--- a/MobileCenter/MobileCenterTests/MSIngestionSenderTests.m
+++ b/MobileCenter/MobileCenterTests/MSIngestionSenderTests.m
@@ -395,7 +395,7 @@ static NSString *const kMSBaseUrl = @"https://test.com";
 
   MSAbstractLog *log = [MSAbstractLog new];
   log.sid = MS_UUID_STRING;
-  log.timestamp = [NSDate date];
+  log.toffset = [NSNumber numberWithLongLong:(long long)([MSUtility nowInMilliseconds])];
 
   // Log does not have device info, therefore, it's an invalid log
   MSLogContainer *container = [[MSLogContainer alloc] initWithBatchId:@"1" andLogs:(NSArray<id<MSLog>> *)@[ log ]];
@@ -651,12 +651,12 @@ static NSString *const kMSBaseUrl = @"https://test.com";
 
   MSMockLog *log1 = [[MSMockLog alloc] init];
   log1.sid = MS_UUID_STRING;
-  log1.timestamp = [NSDate date];
+  log1.toffset = [NSNumber numberWithLongLong:(long long)([MSUtility nowInMilliseconds])];
   log1.device = deviceMock;
 
   MSMockLog *log2 = [[MSMockLog alloc] init];
   log2.sid = MS_UUID_STRING;
-  log2.timestamp = [NSDate date];
+  log2.toffset = [NSNumber numberWithLongLong:(long long)([MSUtility nowInMilliseconds])];
   log2.device = deviceMock;
 
   MSLogContainer *logContainer =

--- a/MobileCenter/MobileCenterTests/MSLogContainerTests.m
+++ b/MobileCenter/MobileCenterTests/MSLogContainerTests.m
@@ -16,11 +16,11 @@
 
   MSAbstractLog *log1 = [MSAbstractLog new];
   log1.sid = MS_UUID_STRING;
-  log1.timestamp = [NSDate date];
+  log1.toffset = [NSNumber numberWithLongLong:(long long)([MSUtility nowInMilliseconds])];
 
   MSAbstractLog *log2 = [MSAbstractLog new];
   log2.sid = MS_UUID_STRING;
-  log2.timestamp = [NSDate date];
+  log2.toffset = [NSNumber numberWithLongLong:(long long)([MSUtility nowInMilliseconds])];
 
   logContainer.logs = (NSArray<id<MSLog>> *)@[ log1, log2 ];
 

--- a/MobileCenterAnalytics/MobileCenterAnalytics/Internals/Session/MSSessionHistoryInfo.h
+++ b/MobileCenterAnalytics/MobileCenterAnalytics/Internals/Session/MSSessionHistoryInfo.h
@@ -5,10 +5,10 @@
 /**
  * Initializes a new `MSSessionHistoryInfo` instance.
  *
- * @param timestamp Timestamp
+ * @param toffset Time offset
  * @param sessionId Session Id
  */
-- (instancetype)initWithTimestamp:(NSDate *)timestamp andSessionId:(NSString *)sessionId;
+- (instancetype)initWithTOffset:(NSNumber *)toffset andSessionId:(NSString *)sessionId;
 
 /**
  *  Session Id.
@@ -16,8 +16,8 @@
 @property(nonatomic, copy) NSString *sessionId;
 
 /**
- *  Timestamp.
+ *  Time offset.
  */
-@property(nonatomic) NSDate *timestamp;
+@property(nonatomic) NSNumber *toffset;
 
 @end

--- a/MobileCenterAnalytics/MobileCenterAnalytics/Internals/Session/MSSessionHistoryInfo.m
+++ b/MobileCenterAnalytics/MobileCenterAnalytics/Internals/Session/MSSessionHistoryInfo.m
@@ -1,7 +1,7 @@
 #import "MSSessionHistoryInfo.h"
 
 static NSString *const kMSSessionIdKey = @"sessionIdKey";
-static NSString *const kMSTimestampKey = @"timestampKey";
+static NSString *const kMSToffsetKey = @"toffsetKey";
 
 /**
  * This class is used to associate session id with the timestamp that it was created.
@@ -12,21 +12,21 @@ static NSString *const kMSTimestampKey = @"timestampKey";
   self = [super init];
   if (self) {
     _sessionId = [coder decodeObjectForKey:kMSSessionIdKey];
-    _timestamp = [coder decodeObjectForKey:kMSTimestampKey];
+    _toffset = [coder decodeObjectForKey:kMSToffsetKey];
   }
   return self;
 }
 
 - (void)encodeWithCoder:(NSCoder *)coder {
   [coder encodeObject:self.sessionId forKey:kMSSessionIdKey];
-  [coder encodeObject:self.timestamp forKey:kMSTimestampKey];
+  [coder encodeObject:self.toffset forKey:kMSToffsetKey];
 }
 
-- (instancetype)initWithTimestamp:(NSDate *)timestamp andSessionId:(NSString *)sessionId {
+- (instancetype)initWithTOffset:(NSNumber *)toffset andSessionId:(NSString *)sessionId {
   self = [super init];
   if (self) {
     _sessionId = sessionId;
-    _timestamp = timestamp;
+    _toffset = toffset;
   }
   return self;
 }

--- a/MobileCenterAnalytics/MobileCenterAnalyticsTests/MSEventLogTests.m
+++ b/MobileCenterAnalytics/MobileCenterAnalyticsTests/MSEventLogTests.m
@@ -34,12 +34,13 @@
   MSDevice *device = [MSDevice new];
   NSString *sessionId = @"1234567890";
   NSDictionary *properties = @{ @"Key" : @"Value" };
-  NSDate *timestamp = [NSDate dateWithTimeIntervalSince1970:42];
+  long long createTime = (long long)[MSUtility nowInMilliseconds];
+  NSNumber *tOffset = @(createTime);
 
   self.sut.eventId = eventId;
   self.sut.name = eventName;
   self.sut.device = device;
-  self.sut.timestamp = timestamp;
+  self.sut.toffset = tOffset;
   self.sut.sid = sessionId;
   self.sut.properties = properties;
 
@@ -55,7 +56,9 @@
   assertThat(actual[@"type"], equalTo(typeName));
   assertThat(actual[@"properties"], equalTo(properties));
   assertThat(actual[@"device"], notNilValue());
-  assertThat(actual[@"timestamp"], equalTo(@"1970-01-01T00:00:42Z"));
+  NSTimeInterval seralizedToffset = [actual[@"toffset"] longLongValue];
+  NSTimeInterval actualToffset = [MSUtility nowInMilliseconds] - createTime;
+  assertThat(@(seralizedToffset), lessThan(@(actualToffset)));
 }
 
 - (void)testNSCodingSerializationAndDeserializationWorks {
@@ -66,13 +69,13 @@
   NSString *eventName = @"eventName";
   MSDevice *device = [MSDevice new];
   NSString *sessionId = @"1234567890";
-  NSDate *timestamp = [NSDate dateWithTimeIntervalSince1970:42];
+  NSNumber *tOffset = @(3);
   NSDictionary *properties = @{ @"Key" : @"Value" };
 
   self.sut.eventId = eventId;
   self.sut.name = eventName;
   self.sut.device = device;
-  self.sut.timestamp = timestamp;
+  self.sut.toffset = tOffset;
   self.sut.sid = sessionId;
   self.sut.properties = properties;
 
@@ -87,7 +90,7 @@
   assertThat(actualEvent.name, equalTo(eventName));
   assertThat(actualEvent.eventId, equalTo(eventId));
   assertThat(actualEvent.device, notNilValue());
-  assertThat(actualEvent.timestamp, equalTo(timestamp));
+  assertThat(actualEvent.toffset, equalTo(tOffset));
   assertThat(actualEvent.type, equalTo(typeName));
   assertThat(actualEvent.sid, equalTo(sessionId));
   assertThat(actualEvent.properties, equalTo(properties));
@@ -99,7 +102,7 @@
   // If
   self.sut.device = OCMClassMock([MSDevice class]);
   OCMStub([self.sut.device isValid]).andReturn(YES);
-  self.sut.timestamp = [NSDate dateWithTimeIntervalSince1970:42];
+  self.sut.toffset = @(3);
   self.sut.sid = @"1234567890";
 
   // Then

--- a/MobileCenterAnalytics/MobileCenterAnalyticsTests/MSPageLogTests.m
+++ b/MobileCenterAnalytics/MobileCenterAnalyticsTests/MSPageLogTests.m
@@ -34,11 +34,12 @@
   MSDevice *device = [MSDevice new];
   NSString *sessionId = @"1234567890";
   NSDictionary *properties = @{ @"Key" : @"Value" };
-  NSDate *timestamp = [NSDate dateWithTimeIntervalSince1970:42];
+  long long createTime = (long long)[MSUtility nowInMilliseconds];
+  NSNumber *tOffset = [NSNumber numberWithLongLong:createTime];
 
   self.sut.name = pageName;
   self.sut.device = device;
-  self.sut.timestamp = timestamp;
+  self.sut.toffset = tOffset;
   self.sut.sid = sessionId;
   self.sut.properties = properties;
 
@@ -53,7 +54,9 @@
   assertThat(actual[@"type"], equalTo(typeName));
   assertThat(actual[@"properties"], equalTo(properties));
   assertThat(actual[@"device"], notNilValue());
-  assertThat(actual[@"timestamp"], equalTo(@"1970-01-01T00:00:42Z"));
+  NSTimeInterval seralizedToffset = [actual[@"toffset"] longLongValue];
+  NSTimeInterval actualToffset = [MSUtility nowInMilliseconds] - createTime;
+  assertThat(@(seralizedToffset), lessThan(@(actualToffset)));
 }
 
 - (void)testNSCodingSerializationAndDeserializationWorks {
@@ -63,12 +66,12 @@
   NSString *pageName = @"pageName";
   MSDevice *device = [MSDevice new];
   NSString *sessionId = @"1234567890";
-  NSDate *timestamp = [NSDate dateWithTimeIntervalSince1970:42];
+  NSNumber *tOffset = @(3);
   NSDictionary *properties = @{ @"Key" : @"Value" };
 
   self.sut.name = pageName;
   self.sut.device = device;
-  self.sut.timestamp = timestamp;
+  self.sut.toffset = tOffset;
   self.sut.sid = sessionId;
   self.sut.properties = properties;
 
@@ -82,7 +85,7 @@
   MSPageLog *actualPage = actual;
   assertThat(actualPage.name, equalTo(pageName));
   assertThat(actualPage.device, notNilValue());
-  assertThat(actualPage.timestamp, equalTo(timestamp));
+  assertThat(actualPage.toffset, equalTo(tOffset));
   assertThat(actualPage.type, equalTo(typeName));
   assertThat(actualPage.sid, equalTo(sessionId));
   assertThat(actualPage.properties, equalTo(properties));
@@ -94,7 +97,7 @@
   // If
   self.sut.device = OCMClassMock([MSDevice class]);
   OCMStub([self.sut.device isValid]).andReturn(YES);
-  self.sut.timestamp = [NSDate dateWithTimeIntervalSince1970:42];
+  self.sut.toffset = @(3);
   self.sut.sid = @"1234567890";
 
   // Then

--- a/MobileCenterAnalytics/MobileCenterAnalyticsTests/MSSessionTrackerTests.m
+++ b/MobileCenterAnalytics/MobileCenterAnalyticsTests/MSSessionTrackerTests.m
@@ -200,23 +200,30 @@ static NSTimeInterval const kMSTestSessionTimeout = 1.5;
 
   // Then
   XCTAssertNil(log.sid);
-  XCTAssertNil(log.timestamp);
+  XCTAssertNil(log.toffset);
 
   // When
   [self.sut onEnqueuingLog:log withInternalId:nil];
 
   // Then
-  XCTAssertNil(log.timestamp);
+  XCTAssertNil(log.toffset);
   XCTAssertEqual(log.sid, self.sut.sessionId);
 
   // When
-  NSDate *timestamp = [NSDate dateWithTimeIntervalSince1970:42];
-  log.timestamp = timestamp;
+  log.toffset = 0;
   [self.sut onEnqueuingLog:log withInternalId:nil];
 
   // Then
-  XCTAssertEqual(timestamp, log.timestamp);
+  XCTAssertEqual(0, log.toffset.integerValue);
   XCTAssertEqual(log.sid, [self.sut.pastSessions firstObject].sessionId);
+
+  // When
+  log.toffset = [NSNumber numberWithUnsignedLongLong:UINT64_MAX];
+  [self.sut onEnqueuingLog:log withInternalId:nil];
+
+  // Then
+  XCTAssertEqual(UINT64_MAX, log.toffset.unsignedLongLongValue);
+  XCTAssertEqual(log.sid, [self.sut.pastSessions lastObject].sessionId);
 }
 
 - (void)testNoStartSessionWithStartSessionLog {
@@ -226,13 +233,13 @@ static NSTimeInterval const kMSTestSessionTimeout = 1.5;
 
   // Then
   XCTAssertNil(log.sid);
-  XCTAssertNil(log.timestamp);
+  XCTAssertNil(log.toffset);
 
   // When
   [self.sut onEnqueuingLog:log withInternalId:nil];
 
   // Then
-  XCTAssertNil(log.timestamp);
+  XCTAssertNil(log.toffset);
   XCTAssertEqual(log.sid, self.sut.sessionId);
 
   // If
@@ -240,13 +247,13 @@ static NSTimeInterval const kMSTestSessionTimeout = 1.5;
 
   // Then
   XCTAssertNil(sessionLog.sid);
-  XCTAssertNil(sessionLog.timestamp);
+  XCTAssertNil(sessionLog.toffset);
 
   // When
   [self.sut onEnqueuingLog:sessionLog withInternalId:nil];
 
   // Then
-  XCTAssertNil(sessionLog.timestamp);
+  XCTAssertNil(sessionLog.toffset);
   XCTAssertNil(sessionLog.sid);
 
   // If
@@ -254,13 +261,13 @@ static NSTimeInterval const kMSTestSessionTimeout = 1.5;
 
   // Then
   XCTAssertNil(serviceLog.sid);
-  XCTAssertNil(serviceLog.timestamp);
+  XCTAssertNil(serviceLog.toffset);
 
   // When
   [self.sut onEnqueuingLog:serviceLog withInternalId:nil];
 
   // Then
-  XCTAssertNil(serviceLog.timestamp);
+  XCTAssertNil(serviceLog.toffset);
   XCTAssertNil(serviceLog.sid);
 }
 

--- a/MobileCenterAnalytics/MobileCenterAnalyticsTests/MSStartSessionLogTests.m
+++ b/MobileCenterAnalytics/MobileCenterAnalyticsTests/MSStartSessionLogTests.m
@@ -32,10 +32,11 @@
   MSDevice *device = [MSDevice new];
   NSString *typeName = @"start_session";
   NSString *sessionId = @"1234567890";
-  NSDate *timestamp = [NSDate dateWithTimeIntervalSince1970:42];
+  long long createTime = (long long)[MSUtility nowInMilliseconds];
+  NSNumber *tOffset = @(createTime);
 
   self.sut.device = device;
-  self.sut.timestamp = timestamp;
+  self.sut.toffset = tOffset;
   self.sut.sid = sessionId;
 
   // When
@@ -45,7 +46,9 @@
   assertThat(actual, notNilValue());
   assertThat(actual[@"type"], equalTo(typeName));
   assertThat(actual[@"device"], notNilValue());
-  assertThat(actual[@"timestamp"], equalTo(@"1970-01-01T00:00:42Z"));
+  NSTimeInterval seralizedToffset = [actual[@"toffset"] longLongValue];
+  NSTimeInterval actualToffset = [MSUtility nowInMilliseconds] - createTime;
+  assertThat(@(seralizedToffset), lessThan(@(actualToffset)));
 }
 
 - (void)testNSCodingSerializationAndDeserializationWorks {
@@ -54,10 +57,10 @@
   MSDevice *device = [MSDevice new];
   NSString *typeName = @"start_session";
   NSString *sessionId = @"1234567890";
-  NSDate *timestamp = [NSDate dateWithTimeIntervalSince1970:42];
+  NSNumber *tOffset = @(3);
 
   self.sut.device = device;
-  self.sut.timestamp = timestamp;
+  self.sut.toffset = tOffset;
   self.sut.sid = sessionId;
 
   // When
@@ -70,7 +73,7 @@
 
   MSStartSessionLog *actualSession = actual;
   assertThat(actualSession.device, notNilValue());
-  assertThat(actualSession.timestamp, equalTo(timestamp));
+  assertThat(actualSession.toffset, equalTo(tOffset));
   assertThat(actualSession.type, equalTo(typeName));
   assertThat(actualSession.sid, equalTo(sessionId));
 }

--- a/MobileCenterCrashes/MobileCenterCrashes/Internals/Model/MSAbstractErrorLog.h
+++ b/MobileCenterCrashes/MobileCenterCrashes/Internals/Model/MSAbstractErrorLog.h
@@ -48,9 +48,9 @@
 @property(nonatomic) BOOL fatal;
 
 /*
- * Timestamp when the app was launched.
+ * Corresponds to the number of milliseconds elapsed between the time the error occurred and the app was launched.
  */
-@property(nonatomic) NSDate *appLaunchTimestamp;
+@property(nonatomic) NSNumber *appLaunchTOffset;
 
 /*
  * CPU Architecture. [optional]

--- a/MobileCenterCrashes/MobileCenterCrashes/Internals/Model/MSAbstractErrorLog.m
+++ b/MobileCenterCrashes/MobileCenterCrashes/Internals/Model/MSAbstractErrorLog.m
@@ -8,7 +8,7 @@ static NSString *const kMSParentProcessName = @"parent_process_name";
 static NSString *const kMSErrorThreadId = @"error_thread_id";
 static NSString *const kMSErrorThreadName = @"error_thread_name";
 static NSString *const kMSFatal = @"fatal";
-static NSString *const kMSAppLaunchTimestamp = @"app_launch_timestamp";
+static NSString *const kMSAppLaunchTOffset = @"app_launch_toffset";
 static NSString *const kMSArchitecture = @"architecture";
 
 @implementation MSAbstractErrorLog
@@ -21,7 +21,7 @@ static NSString *const kMSArchitecture = @"architecture";
 @synthesize errorThreadId = _errorThreadId;
 @synthesize errorThreadName = _errorThreadName;
 @synthesize fatal = _fatal;
-@synthesize appLaunchTimestamp = _appLaunchTimestamp;
+@synthesize appLaunchTOffset = _appLaunchTOffset;
 @synthesize architecture = _architecture;
 
 - (NSMutableDictionary *)serializeToDictionary {
@@ -49,8 +49,8 @@ static NSString *const kMSArchitecture = @"architecture";
     dict[kMSErrorThreadName] = self.errorThreadName;
   }
   dict[kMSFatal] = self.fatal ? @YES : @NO;
-  if (self.appLaunchTimestamp) {
-    dict[kMSAppLaunchTimestamp] = [MSUtility dateToISO8601:self.appLaunchTimestamp];
+  if (self.appLaunchTOffset) {
+    dict[kMSAppLaunchTOffset] = self.appLaunchTOffset;
   }
   if (self.architecture) {
     dict[kMSArchitecture] = self.architecture;
@@ -78,8 +78,8 @@ static NSString *const kMSArchitecture = @"architecture";
          ((!self.errorThreadId && !errorLog.errorThreadId) || [self.errorThreadId isEqual:errorLog.errorThreadId]) &&
          ((!self.errorThreadName && !errorLog.errorThreadName) ||
           [self.errorThreadName isEqualToString:errorLog.errorThreadName]) &&
-         (self.fatal == errorLog.fatal) && ((!self.appLaunchTimestamp && !errorLog.appLaunchTimestamp) ||
-                                            [self.appLaunchTimestamp isEqual:errorLog.appLaunchTimestamp]) &&
+         (self.fatal == errorLog.fatal) && ((!self.appLaunchTOffset && !errorLog.appLaunchTOffset) ||
+                                            [self.appLaunchTOffset isEqual:errorLog.appLaunchTOffset]) &&
          ((!self.architecture && !errorLog.architecture) || [self.architecture isEqualToString:errorLog.architecture]);
 }
 
@@ -96,7 +96,7 @@ static NSString *const kMSArchitecture = @"architecture";
     _errorThreadId = [coder decodeObjectForKey:kMSErrorThreadId];
     _errorThreadName = [coder decodeObjectForKey:kMSErrorThreadName];
     _fatal = [coder decodeBoolForKey:kMSFatal];
-    _appLaunchTimestamp = [coder decodeObjectForKey:kMSAppLaunchTimestamp];
+    _appLaunchTOffset = [coder decodeObjectForKey:kMSAppLaunchTOffset];
     _architecture = [coder decodeObjectForKey:kMSArchitecture];
   }
   return self;
@@ -112,7 +112,7 @@ static NSString *const kMSArchitecture = @"architecture";
   [coder encodeObject:self.errorThreadId forKey:kMSErrorThreadId];
   [coder encodeObject:self.errorThreadName forKey:kMSErrorThreadName];
   [coder encodeBool:self.fatal forKey:kMSFatal];
-  [coder encodeObject:self.appLaunchTimestamp forKey:kMSAppLaunchTimestamp];
+  [coder encodeObject:self.appLaunchTOffset forKey:kMSAppLaunchTOffset];
   [coder encodeObject:self.architecture forKey:kMSArchitecture];
 }
 

--- a/MobileCenterCrashes/MobileCenterCrashesTests/MSAppleErrorLogTests.m
+++ b/MobileCenterCrashes/MobileCenterCrashesTests/MSAppleErrorLogTests.m
@@ -55,7 +55,7 @@
   appleLog.errorThreadId = @2;
   appleLog.errorThreadName = @"2";
   appleLog.fatal = YES;
-  appleLog.appLaunchTimestamp = [NSDate dateWithTimeIntervalSince1970:42];
+  appleLog.appLaunchTOffset = @123;
   appleLog.architecture = @"test";
 
   return appleLog;
@@ -88,7 +88,7 @@
   assertThat(actual[@"error_thread_id"], equalTo(self.sut.errorThreadId));
   assertThat(actual[@"error_thread_name"], equalTo(self.sut.errorThreadName));
   XCTAssertEqual([actual[@"fatal"] boolValue], self.sut.fatal);
-  assertThat(actual[@"app_launch_timestamp"], equalTo(@"1970-01-01T00:00:42Z"));
+  assertThat(actual[@"app_launch_toffset"], equalTo(self.sut.appLaunchTOffset));
   assertThat(actual[@"architecture"], equalTo(self.sut.architecture));
 
   // Exception fields.
@@ -155,11 +155,12 @@
   log.device = OCMClassMock([MSDevice class]);
   OCMStub([log.device isValid]).andReturn(YES);
   log.sid = @"sid";
-  log.timestamp = [NSDate dateWithTimeIntervalSince1970:42];
+  log.toffset = @123;
   log.errorId = @"errorId";
   log.processId = @123;
   log.processName = @"processName";
-  log.appLaunchTimestamp = [NSDate dateWithTimeIntervalSince1970:442];
+  log.appLaunchTOffset = @1234567;
+  log.toffset = @(1);
   log.sid = MS_UUID_STRING;
 
   // Then

--- a/MobileCenterCrashes/MobileCenterCrashesTests/MSCrashesTests.mm
+++ b/MobileCenterCrashes/MobileCenterCrashesTests/MSCrashesTests.mm
@@ -583,7 +583,7 @@ static unsigned int kMaxAttachmentsPerCrashReport = 2;
   for(unsigned int i = 0; i < kMaxAttachmentsPerCrashReport + 1; ++i) {
     NSString *text = [NSString stringWithFormat:@"%d", i];
     MSErrorAttachmentLog *log = [[MSErrorAttachmentLog alloc] initWithFilename:text attachmentText:text];
-    log.timestamp = [NSDate dateWithTimeIntervalSince1970:42];
+    log.toffset = [NSNumber numberWithInt:0];
     log.device = deviceMock;
     [logs addObject:log];
   }

--- a/MobileCenterCrashes/MobileCenterCrashesTests/MSErrorAttachmentLogTests.m
+++ b/MobileCenterCrashes/MobileCenterCrashesTests/MSErrorAttachmentLogTests.m
@@ -189,7 +189,7 @@
 #pragma mark - Utility
 
 - (void)setDummyParentProperties:(MSErrorAttachmentLog *)attachment {
-  attachment.timestamp = [NSDate dateWithTimeIntervalSince1970:42];
+  attachment.toffset = @(1);
   attachment.sid = MS_UUID_STRING;
   attachment.device = OCMClassMock([MSDevice class]);
   OCMStub([attachment.device isValid]).andReturn(YES);

--- a/MobileCenterCrashes/MobileCenterCrashesTests/MSErrorLogFormatterTests.mm
+++ b/MobileCenterCrashes/MobileCenterCrashesTests/MSErrorLogFormatterTests.mm
@@ -405,9 +405,15 @@
   assertThat(errorLog.processName, equalTo(crashReport.processInfo.processName));
   assertThat(errorLog.parentProcessId, equalTo(@(crashReport.processInfo.parentProcessID)));
   assertThat(errorLog.parentProcessName, equalTo(crashReport.processInfo.parentProcessName));
+
   assertThat(errorLog.errorThreadId, equalTo(@(crashedThread.threadNumber)));
-  assertThat(errorLog.timestamp, equalTo(crashReport.systemInfo.timestamp));
-  assertThat(errorLog.appLaunchTimestamp, equalTo(crashReport.processInfo.processStartTime));
+
+  NSDate *appStartTime = [NSDate
+      dateWithTimeIntervalSince1970:(([errorLog.toffset doubleValue] - [errorLog.appLaunchTOffset doubleValue]) /
+                                     1000)];
+  NSDate *appErrorTime = [NSDate dateWithTimeIntervalSince1970:([errorLog.toffset doubleValue] / 1000)];
+  assertThat(appErrorTime, equalTo(crashReport.systemInfo.timestamp));
+  assertThat(appStartTime, equalTo(crashReport.processInfo.processStartTime));
 
   NSArray *images = crashReport.images;
   for (MSPLCrashReportBinaryImageInfo *image in images) {

--- a/MobileCenterPush/MobileCenterPushTests/MSPushLogTests.m
+++ b/MobileCenterPush/MobileCenterPushTests/MSPushLogTests.m
@@ -67,7 +67,7 @@
   // If
   self.sut.device = OCMClassMock([MSDevice class]);
   OCMStub([self.sut.device isValid]).andReturn(YES);
-  self.sut.timestamp = [NSDate dateWithTimeIntervalSince1970:42];
+  self.sut.toffset = @(3);
   self.sut.sid = @"1234567890";
 
   // Then


### PR DESCRIPTION
Reverts Microsoft/mobile-center-sdk-ios#665

We need to wait backend to fix app_launch_timestamp on crashes before merging this, it's broken right now.