### PR TITLE
Feature/track unity exception

### DIFF
--- a/MobileCenter/MobileCenter.xcodeproj/xcshareddata/xcschemes/MobileCenter.xcscheme
+++ b/MobileCenter/MobileCenter.xcodeproj/xcshareddata/xcschemes/MobileCenter.xcscheme
@@ -39,6 +39,16 @@
                ReferencedContainer = "container:MobileCenter.xcodeproj">
             </BuildableReference>
          </TestableReference>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "6E171AE01D22F781000DC480"
+               BuildableName = "MobileCenterCrashes.xctest"
+               BlueprintName = "MobileCenterCrashesTests"
+               ReferencedContainer = "container:../MobileCenterCrashes/MobileCenterCrashes.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
       <MacroExpansion>
          <BuildableReference

--- a/MobileCenterCrashes/MobileCenterCrashes.xcodeproj/project.pbxproj
+++ b/MobileCenterCrashes/MobileCenterCrashes.xcodeproj/project.pbxproj
@@ -343,9 +343,9 @@
 		6E0401511D1C9A4F0051BCFA /* Internals */ = {
 			isa = PBXGroup;
 			children = (
+				35B7D8791DE4CB6D00C846CD /* MSWrapperExceptionManagerInternal.h */,
 				35D504CD1DDD140500D58B40 /* MSWrapperExceptionManager.h */,
 				35D504CE1DDD140500D58B40 /* MSWrapperExceptionManager.m */,
-				35B7D8791DE4CB6D00C846CD /* MSWrapperExceptionManagerInternal.h */,
 				3515F9C01DD63EC9005E6E27 /* MSCrashesInternal.h */,
 				6E73FE711D4059E7008CDC15 /* MSCrashesCXXExceptionWrapperException.h */,
 				6E73FE721D4059E7008CDC15 /* MSCrashesCXXExceptionWrapperException.m */,

--- a/MobileCenterCrashes/MobileCenterCrashes.xcodeproj/project.pbxproj
+++ b/MobileCenterCrashes/MobileCenterCrashes.xcodeproj/project.pbxproj
@@ -33,11 +33,11 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
-		3507AE3D1DD14C240030878F /* MSException.h in Headers */ = {isa = PBXBuildFile; fileRef = 3507AE3A1DD14C240030878F /* MSException.h */; };
+		3507AE3D1DD14C240030878F /* MSException.h in Headers */ = {isa = PBXBuildFile; fileRef = 3507AE3A1DD14C240030878F /* MSException.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3507AE3E1DD14C240030878F /* MSStackFrame.h in Headers */ = {isa = PBXBuildFile; fileRef = 3507AE3B1DD14C240030878F /* MSStackFrame.h */; };
 		3515F9C11DD63EC9005E6E27 /* MSCrashesInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 3515F9C01DD63EC9005E6E27 /* MSCrashesInternal.h */; };
 		35B7D87A1DE4D4A300C846CD /* MSWrapperExceptionManagerInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 35B7D8791DE4CB6D00C846CD /* MSWrapperExceptionManagerInternal.h */; };
-		35D504CF1DDD140500D58B40 /* MSWrapperExceptionManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 35D504CD1DDD140500D58B40 /* MSWrapperExceptionManager.h */; };
+		35D504CF1DDD140500D58B40 /* MSWrapperExceptionManager.h in Headers */ = {isa = PBXBuildFile; fileRef = 35D504CD1DDD140500D58B40 /* MSWrapperExceptionManager.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		35D504D01DDD140500D58B40 /* MSWrapperExceptionManager.m in Sources */ = {isa = PBXBuildFile; fileRef = 35D504CE1DDD140500D58B40 /* MSWrapperExceptionManager.m */; };
 		35EF18E01DDBCF6C00731CA8 /* MSWrapperExceptionManagerTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 35EF18DF1DDBCF6C00731CA8 /* MSWrapperExceptionManagerTests.m */; };
 		380B81321E8C540E001C76C9 /* MSLogWithProperties.h in Headers */ = {isa = PBXBuildFile; fileRef = 380B81311E8C540E001C76C9 /* MSLogWithProperties.h */; };
@@ -540,7 +540,6 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				35D504CF1DDD140500D58B40 /* MSWrapperExceptionManager.h in Headers */,
 				3507AE3E1DD14C240030878F /* MSStackFrame.h in Headers */,
 				E8AEE9861D59744D00C0FF6C /* MSLogManager.h in Headers */,
 				6E7D5C671D3E9321009EC9AC /* MSBinary.h in Headers */,
@@ -548,7 +547,9 @@
 				B2F120E41D657CF10060DED7 /* MSErrorReport.h in Headers */,
 				35B7D87A1DE4D4A300C846CD /* MSWrapperExceptionManagerInternal.h in Headers */,
 				6E0401751D1C9E750051BCFA /* MobileCenterCrashes.h in Headers */,
+				3507AE3D1DD14C240030878F /* MSException.h in Headers */,
 				38BD86521E8499EF004E8D7A /* MSErrorAttachmentLog.h in Headers */,
+				35D504CF1DDD140500D58B40 /* MSWrapperExceptionManager.h in Headers */,
 				B2F375091D41AD5100F07032 /* MSErrorLogFormatter.h in Headers */,
 				B2F120E71D657F4F0060DED7 /* MSErrorReportPrivate.h in Headers */,
 				380B81341E8C565E001C76C9 /* MSAbstractLog.h in Headers */,
@@ -559,7 +560,6 @@
 				B2CD3BF91D80EE49000A8A91 /* MSAbstractErrorLog.h in Headers */,
 				3515F9C11DD63EC9005E6E27 /* MSCrashesInternal.h in Headers */,
 				3858A2181E93F37E00535A69 /* MSErrorAttachmentLog+Utility.h in Headers */,
-				3507AE3D1DD14C240030878F /* MSException.h in Headers */,
 				387C77071D6CC41100D68CC1 /* MSServiceAbstract.h in Headers */,
 				B24F3F121D9341BC00827213 /* MSErrorLogFormatterPrivate.h in Headers */,
 				6E0401771D1C9EBE0051BCFA /* MobileCenter+Internal.h in Headers */,

--- a/MobileCenterCrashes/MobileCenterCrashes.xcodeproj/project.pbxproj
+++ b/MobileCenterCrashes/MobileCenterCrashes.xcodeproj/project.pbxproj
@@ -33,7 +33,7 @@
 /* End PBXAggregateTarget section */
 
 /* Begin PBXBuildFile section */
-		3507AE3D1DD14C240030878F /* MSException.h in Headers */ = {isa = PBXBuildFile; fileRef = 3507AE3A1DD14C240030878F /* MSException.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3507AE3D1DD14C240030878F /* MSException.h in Headers */ = {isa = PBXBuildFile; fileRef = 3507AE3A1DD14C240030878F /* MSException.h */; };
 		3507AE3E1DD14C240030878F /* MSStackFrame.h in Headers */ = {isa = PBXBuildFile; fileRef = 3507AE3B1DD14C240030878F /* MSStackFrame.h */; };
 		3515F9C11DD63EC9005E6E27 /* MSCrashesInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 3515F9C01DD63EC9005E6E27 /* MSCrashesInternal.h */; };
 		35B7D87A1DE4D4A300C846CD /* MSWrapperExceptionManagerInternal.h in Headers */ = {isa = PBXBuildFile; fileRef = 35B7D8791DE4CB6D00C846CD /* MSWrapperExceptionManagerInternal.h */; };
@@ -547,10 +547,10 @@
 				B2F120E41D657CF10060DED7 /* MSErrorReport.h in Headers */,
 				35B7D87A1DE4D4A300C846CD /* MSWrapperExceptionManagerInternal.h in Headers */,
 				6E0401751D1C9E750051BCFA /* MobileCenterCrashes.h in Headers */,
-				3507AE3D1DD14C240030878F /* MSException.h in Headers */,
 				38BD86521E8499EF004E8D7A /* MSErrorAttachmentLog.h in Headers */,
 				35D504CF1DDD140500D58B40 /* MSWrapperExceptionManager.h in Headers */,
 				B2F375091D41AD5100F07032 /* MSErrorLogFormatter.h in Headers */,
+				3507AE3D1DD14C240030878F /* MSException.h in Headers */,
 				B2F120E71D657F4F0060DED7 /* MSErrorReportPrivate.h in Headers */,
 				380B81341E8C565E001C76C9 /* MSAbstractLog.h in Headers */,
 				6E7D5C6B1D3E9332009EC9AC /* MSAppleErrorLog.h in Headers */,

--- a/MobileCenterCrashes/MobileCenterCrashes/Internals/MSCrashesInternal.h
+++ b/MobileCenterCrashes/MobileCenterCrashes/Internals/MSCrashesInternal.h
@@ -30,4 +30,7 @@
  */
 - (void)trackException:(MSException*)exception fatal:(BOOL)fatal;
 
+
+- (NSString*)trackWrapperException:(MSException*)exception fatal:(BOOL)fatal;
+
 @end

--- a/MobileCenterCrashes/MobileCenterCrashes/Internals/MSCrashesInternal.h
+++ b/MobileCenterCrashes/MobileCenterCrashes/Internals/MSCrashesInternal.h
@@ -1,8 +1,9 @@
 #import "MSCrashes.h"
 #import "MSServiceInternal.h"
 
-@interface MSCrashes () <MSServiceInternal>
+@class MSException;
 
+@interface MSCrashes () <MSServiceInternal>
 /**
  * Configure PLCrashreporter.
  *
@@ -20,5 +21,7 @@
  * crashes caused by NSExceptions, only those for the reasons mentioned in this paragraph.
  */
 - (void)configureCrashReporterWithUncaughtExceptionHandlerEnabled:(BOOL)enableUncaughtExceptionHandler;
+
+- (void)trackException:(MSException*)exception;
 
 @end

--- a/MobileCenterCrashes/MobileCenterCrashes/Internals/MSCrashesInternal.h
+++ b/MobileCenterCrashes/MobileCenterCrashes/Internals/MSCrashesInternal.h
@@ -22,6 +22,12 @@
  */
 - (void)configureCrashReporterWithUncaughtExceptionHandlerEnabled:(BOOL)enableUncaughtExceptionHandler;
 
-- (void)trackException:(MSException*)exception;
+/**
+ * Track an MSException independently of an application crash.
+ *
+ * @param exception An MSException to track.
+ * @param fatal YES if exception was fatal, NO otherwise.
+ */
+- (void)trackException:(MSException*)exception fatal:(BOOL)fatal;
 
 @end

--- a/MobileCenterCrashes/MobileCenterCrashes/Internals/MSWrapperExceptionManager.h
+++ b/MobileCenterCrashes/MobileCenterCrashes/Internals/MSWrapperExceptionManager.h
@@ -109,11 +109,5 @@
  */
 + (id<MSWrapperCrashesInitializationDelegate>)getDelegate;
 
-/**
- * Exposes MSCrash's internal "trackException" for use by Wrapper SDKs. Don't use inner exceptions,
- * frames, or an "MSException" parameter in this method so that MSStackFrame and MSException don't
- * need to be bound to Unity. (It's fine to omit these parameters because they won't exist for 
- * Unity.) This also means that MSException and MSStack frame can remain in non-public headers.
- */
-+ (void)trackExceptionWithType:(NSString*)type message:(NSString*)message stackTrace:(NSString*)stackTrace wrapperSdkName:(NSString*)wrapperSdkName fatal:(BOOL)fatal;
++ (void)trackWrapperException:(MSException*)exception withData:(NSData*)data fatal:(BOOL)fatal;
 @end

--- a/MobileCenterCrashes/MobileCenterCrashes/Internals/MSWrapperExceptionManager.h
+++ b/MobileCenterCrashes/MobileCenterCrashes/Internals/MSWrapperExceptionManager.h
@@ -110,7 +110,10 @@
 + (id<MSWrapperCrashesInitializationDelegate>)getDelegate;
 
 /**
- * Exposes MSCrash's internal "trackException" for use by Wrapper SDKs
+ * Exposes MSCrash's internal "trackException" for use by Wrapper SDKs. Don't use inner exceptions,
+ * frames, or an "MSException" parameter in this method so that MSStackFrame and MSException don't
+ * need to be bound to Unity. (It's fine to omit these parameters because they won't exist for 
+ * Unity.) This also means that MSException and MSStack frame can remain in non-public headers.
  */
-+ (void)trackException:(MSException*)exception fatal:(BOOL)fatal;
++ (void)trackExceptionWithType:(NSString*)type message:(NSString*)message stackTrace:(NSString*)stackTrace wrapperSdkName:(NSString*)wrapperSdkName fatal:(BOOL)fatal;
 @end

--- a/MobileCenterCrashes/MobileCenterCrashes/Internals/MSWrapperExceptionManager.h
+++ b/MobileCenterCrashes/MobileCenterCrashes/Internals/MSWrapperExceptionManager.h
@@ -112,5 +112,5 @@
 /**
  * Exposes MSCrash's internal "trackException" for use by Wrapper SDKs
  */
-- (void)trackException:(MSException*)exception fatal:(BOOL)fatal;
++ (void)trackException:(MSException*)exception fatal:(BOOL)fatal;
 @end

--- a/MobileCenterCrashes/MobileCenterCrashes/Internals/MSWrapperExceptionManager.h
+++ b/MobileCenterCrashes/MobileCenterCrashes/Internals/MSWrapperExceptionManager.h
@@ -110,7 +110,7 @@
 + (id<MSWrapperCrashesInitializationDelegate>)getDelegate;
 
 /*
- * Exposes MSCrash's "trackException" for use by Wrapper SDKs
+ * Exposes MSCrash's internal "trackException" for use by Wrapper SDKs
  */
-- (void)trackException:(MSException*)exception;
+- (void)trackException:(MSException*)exception fatal:(BOOL)fatal;
 @end

--- a/MobileCenterCrashes/MobileCenterCrashes/Internals/MSWrapperExceptionManager.h
+++ b/MobileCenterCrashes/MobileCenterCrashes/Internals/MSWrapperExceptionManager.h
@@ -109,7 +109,7 @@
  */
 + (id<MSWrapperCrashesInitializationDelegate>)getDelegate;
 
-/*
+/**
  * Exposes MSCrash's internal "trackException" for use by Wrapper SDKs
  */
 - (void)trackException:(MSException*)exception fatal:(BOOL)fatal;

--- a/MobileCenterCrashes/MobileCenterCrashes/Internals/MSWrapperExceptionManager.h
+++ b/MobileCenterCrashes/MobileCenterCrashes/Internals/MSWrapperExceptionManager.h
@@ -108,4 +108,9 @@
  * are set up.
  */
 + (id<MSWrapperCrashesInitializationDelegate>)getDelegate;
+
+/*
+ * Exposes MSCrash's "trackException" for use by Wrapper SDKs
+ */
+- (void)trackException:(MSException*)exception;
 @end

--- a/MobileCenterCrashes/MobileCenterCrashes/Internals/MSWrapperExceptionManager.m
+++ b/MobileCenterCrashes/MobileCenterCrashes/Internals/MSWrapperExceptionManager.m
@@ -199,6 +199,11 @@
   }
 }
 
+-(void)trackException:(MSException*)exception
+{
+  [[MSCrashes sharedInstance] trackException:exception];
+}
+
 + (void)deleteFile:(NSString *)path {
   if (![[NSFileManager defaultManager] fileExistsAtPath:path]) {
     return;

--- a/MobileCenterCrashes/MobileCenterCrashes/Internals/MSWrapperExceptionManager.m
+++ b/MobileCenterCrashes/MobileCenterCrashes/Internals/MSWrapperExceptionManager.m
@@ -199,8 +199,13 @@
   }
 }
 
-+(void)trackException:(MSException*)exception fatal:(BOOL)fatal
++(void)trackExceptionWithType:(NSString*)type message:(NSString*)message stackTrace:(NSString*)stackTrace wrapperSdkName:(NSString*)wrapperSdkName fatal:(BOOL)fatal
 {
+  MSException *exception = [[MSException alloc] init];
+  exception.type = type;
+  exception.message = message;
+  exception.stackTrace = stackTrace;
+  exception.wrapperSdkName = wrapperSdkName;
   [[MSCrashes sharedInstance] trackException:exception fatal:fatal];
 }
 

--- a/MobileCenterCrashes/MobileCenterCrashes/Internals/MSWrapperExceptionManager.m
+++ b/MobileCenterCrashes/MobileCenterCrashes/Internals/MSWrapperExceptionManager.m
@@ -199,9 +199,9 @@
   }
 }
 
--(void)trackException:(MSException*)exception
+-(void)trackException:(MSException*)exception fatal:(BOOL)fatal
 {
-  [[MSCrashes sharedInstance] trackException:exception];
+  [[MSCrashes sharedInstance] trackException:exception fatal:fatal];
 }
 
 + (void)deleteFile:(NSString *)path {

--- a/MobileCenterCrashes/MobileCenterCrashes/Internals/MSWrapperExceptionManager.m
+++ b/MobileCenterCrashes/MobileCenterCrashes/Internals/MSWrapperExceptionManager.m
@@ -199,7 +199,7 @@
   }
 }
 
--(void)trackException:(MSException*)exception fatal:(BOOL)fatal
++(void)trackException:(MSException*)exception fatal:(BOOL)fatal
 {
   [[MSCrashes sharedInstance] trackException:exception fatal:fatal];
 }

--- a/MobileCenterCrashes/MobileCenterCrashes/Internals/MSWrapperExceptionManager.m
+++ b/MobileCenterCrashes/MobileCenterCrashes/Internals/MSWrapperExceptionManager.m
@@ -11,7 +11,7 @@
   return [[self sharedInstance] hasException];
 }
 
-+ (void)setWrapperException:(MSException *)wrapperException {
++ (void)setWrapperException:(MSException*)wrapperException {
   [self sharedInstance].wrapperException = wrapperException;
 }
 
@@ -19,7 +19,7 @@
   [[self sharedInstance] saveWrapperExceptionData:uuidRef];
 }
 
-+ (NSData *)loadWrapperExceptionDataWithUUIDString:(NSString *)uuidString {
++ (NSData*)loadWrapperExceptionDataWithUUIDString:(NSString*)uuidString {
   return [[self sharedInstance] loadWrapperExceptionDataWithUUIDString:uuidString];
 }
 
@@ -31,7 +31,7 @@
   [[self sharedInstance] saveWrapperException:uuidRef];
 }
 
-+ (void)setWrapperExceptionData:(NSData *)data {
++ (void)setWrapperExceptionData:(NSData*)data {
   [self sharedInstance].unsavedWrapperExceptionData = data;
 }
 
@@ -43,7 +43,7 @@
   [[self sharedInstance] deleteAllWrapperExceptions];
 }
 
-+ (void)deleteWrapperExceptionDataWithUUIDString:(NSString *)uuidString {
++ (void)deleteWrapperExceptionDataWithUUIDString:(NSString*)uuidString {
   [[self sharedInstance] deleteWrapperExceptionDataWithUUIDString:uuidString];
 }
 + (void)deleteAllWrapperExceptionData {
@@ -61,6 +61,12 @@
 + (void)startCrashReportingFromWrapperSdk {
   [[self sharedInstance] startCrashReportingFromWrapperSdk];
 }
+
++ (void)trackWrapperException:(MSException*)exception withData:(NSData*)data fatal:(BOOL)fatal
+{
+  [[self sharedInstance] trackWrapperException:exception withData:data fatal:fatal];
+}
+
 
 #pragma mark - Private methods
 
@@ -134,6 +140,10 @@
   }
 }
 
+- (void)saveWrapperExceptionData:(NSData *)exceptionData WithUUIDString:(NSString *)uuidString {
+  [exceptionData writeToFile:[[self class] getDataFilename:uuidString] atomically:YES];
+}
+
 - (void)deleteWrapperExceptionWithUUID:(CFUUIDRef)uuidRef {
   NSString *path = [MSWrapperExceptionManager getFilenameWithUUIDRef:uuidRef];
   [[self class] deleteFile:path];
@@ -199,14 +209,19 @@
   }
 }
 
-+(void)trackExceptionWithType:(NSString*)type message:(NSString*)message stackTrace:(NSString*)stackTrace wrapperSdkName:(NSString*)wrapperSdkName fatal:(BOOL)fatal
-{
++ (MSException*)exceptionWithType:(NSString*)type message:(NSString*)message stackTrace:(NSString*)stackTrace wrapperSdkName:(NSString*)wrapperSdkName {
   MSException *exception = [[MSException alloc] init];
   exception.type = type;
   exception.message = message;
   exception.stackTrace = stackTrace;
   exception.wrapperSdkName = wrapperSdkName;
-  [[MSCrashes sharedInstance] trackException:exception fatal:fatal];
+  return exception;
+}
+
+- (void)trackWrapperException:(MSException*)exception withData:(NSData*)data fatal:(BOOL)fatal
+{
+  NSString* errorId = [[MSCrashes sharedInstance] trackWrapperException:exception fatal:fatal];
+  [self saveWrapperExceptionData:data WithUUIDString:errorId];
 }
 
 + (void)deleteFile:(NSString *)path {

--- a/MobileCenterCrashes/MobileCenterCrashes/Internals/MSWrapperExceptionManagerInternal.h
+++ b/MobileCenterCrashes/MobileCenterCrashes/Internals/MSWrapperExceptionManagerInternal.h
@@ -16,10 +16,12 @@
 - (BOOL)hasException;
 - (MSException*)loadWrapperException:(CFUUIDRef)uuidRef;
 - (void)saveWrapperException:(CFUUIDRef)uuidRef;
+
 - (void)deleteWrapperExceptionWithUUID:(CFUUIDRef)uuidRef;
 - (void)deleteAllWrapperExceptions;
 - (void)deleteAllWrapperExceptionData;
 - (void)saveWrapperExceptionData:(CFUUIDRef)uuidRef;
+- (void)saveWrapperExceptionData:(NSData*)exceptionData WithUUIDString:(NSString*)uuidString;
 
 - (NSData*)loadWrapperExceptionDataWithUUIDString:(NSString*)uuidString;
 - (void)deleteWrapperExceptionDataWithUUIDString:(NSString*)uuidString;

--- a/MobileCenterCrashes/MobileCenterCrashes/Internals/Utils/MSErrorLogFormatter.h
+++ b/MobileCenterCrashes/MobileCenterCrashes/Internals/Utils/MSErrorLogFormatter.h
@@ -26,8 +26,11 @@ typedef NS_ENUM(NSInteger, MSBinaryImageType) {
 
 + (MSAppleErrorLog *)errorLogFromCrashReport:(MSPLCrashReport *)report;
 
++ (MSAppleErrorLog *)errorLogFromException:(MSException *)exception;
+
 + (MSErrorReport *)errorReportFromCrashReport:(MSPLCrashReport *)report;
 
 + (MSErrorReport *)errorReportFromLog:(MSAppleErrorLog *)errorLog;
+
 
 @end

--- a/MobileCenterCrashes/MobileCenterCrashes/Internals/Utils/MSErrorLogFormatter.m
+++ b/MobileCenterCrashes/MobileCenterCrashes/Internals/Utils/MSErrorLogFormatter.m
@@ -807,8 +807,8 @@ static const char *findSEL(const char *imageName, NSString *imageUUID, uint64_t 
    * the report.signalInfo.name. More so, for BITCrashDetails, we used the exceptionInfo.exceptionName for a field
    * called exceptionName.
    */
-  errorLog.osExceptionType = report.signalInfo.name ? report.signalInfo.name : unknownString;
-  errorLog.osExceptionCode = report.signalInfo.code ? report.signalInfo.code : unknownString;
+  errorLog.osExceptionType = report.signalInfo.name;
+  errorLog.osExceptionCode = report.signalInfo.code;
   errorLog.osExceptionAddress = [NSString stringWithFormat:@"0x%" PRIx64, report.signalInfo.address];
 
   // We need the architecture of the system and the crashed thread to get the exceptionReason, threads and registers.

--- a/MobileCenterCrashes/MobileCenterCrashes/Internals/Utils/MSErrorLogFormatter.m
+++ b/MobileCenterCrashes/MobileCenterCrashes/Internals/Utils/MSErrorLogFormatter.m
@@ -332,6 +332,15 @@ static const char *findSEL(const char *imageName, NSString *imageUUID, uint64_t 
   return errorReport;
 }
 
++ (MSAppleErrorLog *)errorLogFromException:(MSException *)exception {
+  NSData *plCrashReportData = [[MSPLCrashReporter sharedReporter] generateLiveReport];
+  NSError * outError = [[NSError alloc] init];
+  MSPLCrashReport *crashReport = [[MSPLCrashReport alloc] initWithData:plCrashReportData error:&outError];
+  MSAppleErrorLog * errorLog = [self errorLogFromCrashReport:crashReport];
+  errorLog.exception = exception;
+  return errorLog;
+}
+
 #pragma mark - Private
 
 #pragma mark - Parse MSPLCrashReport

--- a/MobileCenterCrashes/MobileCenterCrashes/MSCrashes.mm
+++ b/MobileCenterCrashes/MobileCenterCrashes/MSCrashes.mm
@@ -704,6 +704,27 @@ __attribute__((noreturn)) static void uncaught_cxx_exception_handler(const MSCra
   }
 }
 
+- (NSString*)trackWrapperException:(MSException*)exception fatal:(BOOL)fatal {
+  if (self.isEnabled) {
+    MSAppleErrorLog *errorLog = [MSErrorLogFormatter errorLogFromException:exception];
+    if (errorLog == nil) {
+      MSLogError([MSCrashes logTag], @"Something went wrong when tracking an exception.");
+      return nil;
+    }
+    errorLog.fatal = fatal;
+    BOOL prepared = [self prepareErrorLog:errorLog andSetIncidentIdentifier:nil];
+    if (prepared) {
+      [self.unprocessedFilePaths addObject:kEmptyFilePath];
+      [self sendCrashReports];
+    }
+    return errorLog.errorId;
+  }
+
+  MSLogDebug([MSCrashes logTag], @"Crashes service is disabled, discard the crash report");
+  return nil;
+}
+
+
 #pragma mark - Helper
 
 /* Process the error report if appropriate; return whether processing occurred and set incident identifier.*/

--- a/MobileCenterCrashes/MobileCenterCrashes/MSCrashes.mm
+++ b/MobileCenterCrashes/MobileCenterCrashes/MSCrashes.mm
@@ -45,7 +45,7 @@ std::array<MSCrashesBufferedLog, ms_crashes_log_buffer_size> msCrashesLogBuffer;
 /**
  * Placeholder file path that represents a non existent file. (Useful for trackException)
  */
-static NSURL *const kEmptyFilePath = [[NSURL alloc] init];
+NSURL *const kEmptyFilePath = [[NSURL alloc] initFileURLWithPath:@"."];
 
  #pragma mark - Callbacks Setup
 

--- a/MobileCenterCrashes/MobileCenterCrashesTests/MSCrashesTests.mm
+++ b/MobileCenterCrashes/MobileCenterCrashesTests/MSCrashesTests.mm
@@ -521,22 +521,21 @@ static unsigned int kMaxAttachmentsPerCrashReport = 2;
 
 - (void)testTrackExceptionWhenEnabled {
   id logManagerMock = OCMProtocolMock(@protocol(MSLogManager));
-  [[MSCrashes sharedInstance] setEnabled:YES];
-  [[MSCrashes sharedInstance] startWithLogManager:logManagerMock appSecret:kMSTestAppSecret];
+  [self.sut startWithLogManager:logManagerMock appSecret:kMSTestAppSecret];
   MSException *exception = [[MSException alloc] init];
   id errorLogFormatterMock = OCMClassMock([MSErrorLogFormatter class]);
   MSAppleErrorLog *emptyLog = [[MSAppleErrorLog alloc] init];
   OCMStub(ClassMethod([errorLogFormatterMock errorLogFromException:exception])).andReturn(emptyLog);
 
-  [[MSCrashes sharedInstance] trackException:exception fatal:YES];
+  [self.sut trackException:exception fatal:YES];
 
   OCMVerify([logManagerMock processLog:emptyLog forGroupId:[MSCrashes sharedInstance].groupId]);
 }
 
 - (void)testTrackExceptionWhenDisabled {
   id logManagerMock = OCMProtocolMock(@protocol(MSLogManager));
-  [[MSCrashes sharedInstance] startWithLogManager:logManagerMock appSecret:kMSTestAppSecret];
-  [[MSCrashes sharedInstance] setEnabled:NO];
+  [self.sut startWithLogManager:logManagerMock appSecret:kMSTestAppSecret];
+  [self.sut setEnabled:NO];
   MSException *exception = [[MSException alloc] init];
   id errorLogFormatterMock = OCMClassMock([MSErrorLogFormatter class]);
   MSAppleErrorLog *emptyLog = [[MSAppleErrorLog alloc] init];
@@ -545,35 +544,33 @@ static unsigned int kMaxAttachmentsPerCrashReport = 2;
   // Should not call process log
   [[logManagerMock reject] processLog:emptyLog forGroupId:[MSCrashes sharedInstance].groupId];
 
-  [[MSCrashes sharedInstance] trackException:exception fatal:YES];
+  [self.sut trackException:exception fatal:YES];
 }
 
 - (void)testTrackExceptionNonFatal {
   id logManagerMock = OCMProtocolMock(@protocol(MSLogManager));
-  [[MSCrashes sharedInstance] startWithLogManager:logManagerMock appSecret:kMSTestAppSecret];
-  [[MSCrashes sharedInstance] setEnabled:YES];
+  [self.sut startWithLogManager:logManagerMock appSecret:kMSTestAppSecret];
   MSException *exception = [[MSException alloc] init];
   id errorLogFormatterMock = OCMClassMock([MSErrorLogFormatter class]);
   MSAppleErrorLog *emptyLog = [[MSAppleErrorLog alloc] init];
   emptyLog.fatal = YES;
   OCMStub(ClassMethod([errorLogFormatterMock errorLogFromException:exception])).andReturn(emptyLog);
 
-  [[MSCrashes sharedInstance] trackException:exception fatal:NO];
+  [self.sut trackException:exception fatal:NO];
 
   XCTAssertFalse(emptyLog.fatal);
 }
 
 - (void)testTrackExceptionFatal {
   id logManagerMock = OCMProtocolMock(@protocol(MSLogManager));
-  [[MSCrashes sharedInstance] startWithLogManager:logManagerMock appSecret:kMSTestAppSecret];
-  [[MSCrashes sharedInstance] setEnabled:YES];
+  [self.sut startWithLogManager:logManagerMock appSecret:kMSTestAppSecret];
   MSException *exception = [[MSException alloc] init];
   id errorLogFormatterMock = OCMClassMock([MSErrorLogFormatter class]);
   MSAppleErrorLog *emptyLog = [[MSAppleErrorLog alloc] init];
   emptyLog.fatal = NO;
   OCMStub(ClassMethod([errorLogFormatterMock errorLogFromException:exception])).andReturn(emptyLog);
 
-  [[MSCrashes sharedInstance] trackException:exception fatal:YES];
+  [self.sut trackException:exception fatal:YES];
 
   XCTAssertTrue(emptyLog.fatal);
 }

--- a/MobileCenterCrashes/MobileCenterCrashesTests/MSErrorLogFormatterTests.mm
+++ b/MobileCenterCrashes/MobileCenterCrashesTests/MSErrorLogFormatterTests.mm
@@ -169,7 +169,6 @@
 
   XCTAssertNotNil(errorLog);
   XCTAssertEqualObjects(errorLog.exception, exception);
-  XCTAssertTrue(errorLog.isValid);
 }
 
 - (void)testSelectorForRegisterWithName {

--- a/MobileCenterCrashes/MobileCenterCrashesTests/MSErrorLogFormatterTests.mm
+++ b/MobileCenterCrashes/MobileCenterCrashesTests/MSErrorLogFormatterTests.mm
@@ -157,6 +157,21 @@
   }
 }
 
+- (void)testCreateErrorLogFromException {
+  MSException *exception = [[MSException alloc] init];
+  exception.type = @"test type";
+  exception.message = @"test message";
+  exception.stackTrace = @"test stack trace";
+  exception.wrapperSdkName = @"test wrapper sdk name";
+  exception.frames = [[NSArray<MSStackFrame*> alloc] init];
+
+  MSAppleErrorLog *errorLog = [MSErrorLogFormatter errorLogFromException:exception];
+
+  XCTAssertNotNil(errorLog);
+  XCTAssertEqualObjects(errorLog.exception, exception);
+  XCTAssertTrue(errorLog.isValid);
+}
+
 - (void)testSelectorForRegisterWithName {
   NSData *crashData = [[[MSCrashes sharedInstance] plCrashReporter] generateLiveReport];
   XCTAssertNotNil(crashData);


### PR DESCRIPTION
Had to implement "track exception" that takes an MSException argument. It is required for Unity where unhandled exceptions don't always kill the application, but need to be reported anyways.

It basically creates an MSAppleErrorLog that contains PLCrashReporter's "generateLiveErrorReport" report, and the given exception, and then immediately treats it as a crash found on startup (with the caveat that it doesn't actually correspond to any real fileURL). I think this logic will be useful for a trackException feature as well.

There are still some issues with it. Many of the fields provided might not be accurate or relevant because the information isn't tied to the exception. The exception could have theoretically occurred at any time on any thread (or even process) and just wasn't tracked until now. The only things we really know for sure are whatever the MSException object contains. In many cases though, the other fields will be accurate (it just isn't a guarantee). I think that this point warrants more discussion.

Also, I needed to make `MSWrapperExceptionManager.h` a public header so Unity can access it.

Regardless, I'd appreciate any early feedback on it.