### PR TITLE
Timestamp instead of toffset in logs

### DIFF
--- a/MobileCenter/MobileCenter/Internals/Channel/MSLogManagerDefault.m
+++ b/MobileCenter/MobileCenter/Internals/Channel/MSLogManagerDefault.m
@@ -145,11 +145,11 @@ static char *const kMSlogsDispatchQueue = "com.microsoft.azure.mobile.mobilecent
 
   /*
    * Set common log info.
-   * Only add toffset and device info in case the log doesn't have one. In case the log is restored after a crash or for
-   * crashes, we don't want the toffset and the device information to be updated but want the old one preserved.
+   * Only add timestamp and device info in case the log doesn't have one. In case the log is restored after a crash or for
+   * crashes, we don't want the timestamp and the device information to be updated but want the old one preserved.
    */
-  if (!log.toffset) {
-    log.toffset = [NSNumber numberWithLongLong:(long long)([MSUtility nowInMilliseconds])];
+  if (!log.timestamp) {
+    log.timestamp = [NSDate date];
   }
   if (!log.device) {
     log.device = [[MSDeviceTracker sharedInstance] device];

--- a/MobileCenter/MobileCenter/Internals/Device/MSDeviceHistoryInfo.h
+++ b/MobileCenter/MobileCenter/Internals/Device/MSDeviceHistoryInfo.h
@@ -8,15 +8,15 @@
 @interface MSDeviceHistoryInfo : NSObject <NSCoding>
 
 /**
- * The tOffset that indicates the moment in time for the device history.
+ * The moment in time for the device history.
  */
-@property (nonatomic) NSNumber *tOffset;
+@property (nonatomic) NSDate *timestamp;
 
 /**
  * Instance of MSDevice.
  */
 @property (nonatomic) MSDevice *device;
 
-- (instancetype)initWithTOffset:(NSNumber *)tOffset andDevice:(MSDevice *)device;
+- (instancetype)initWithTimestamp:(NSDate *)timestamp andDevice:(MSDevice *)device;
 
 @end

--- a/MobileCenter/MobileCenter/Internals/Device/MSDeviceHistoryInfo.m
+++ b/MobileCenter/MobileCenter/Internals/Device/MSDeviceHistoryInfo.m
@@ -1,13 +1,13 @@
 #import "MSDeviceHistoryInfo.h"
 
 static NSString *const kMSDeviceKey = @"deviceKey";
-static NSString *const kMSToffsetKey = @"toffsetKey";
+static NSString *const kMSTimestampKey = @"timestampKey";
 
 @implementation MSDeviceHistoryInfo
 
-- (instancetype)initWithTOffset:(NSNumber *)tOffset andDevice:(MSDevice *)device {
+- (instancetype)initWithTimestamp:(NSDate *)timestamp andDevice:(MSDevice *)device {
   if ((self = [super init])) {
-    _tOffset = tOffset;
+    _timestamp = timestamp;
     _device = device;
   }
   return self;
@@ -18,7 +18,7 @@ static NSString *const kMSToffsetKey = @"toffsetKey";
 - (instancetype)initWithCoder:(NSCoder *)coder {
   self = [super init];
   if (self) {
-    self.tOffset = [coder decodeObjectForKey:kMSToffsetKey];
+    self.timestamp = [coder decodeObjectForKey:kMSTimestampKey];
     self.device = [coder decodeObjectForKey:kMSDeviceKey];
   }
 
@@ -26,7 +26,7 @@ static NSString *const kMSToffsetKey = @"toffsetKey";
 }
 
 - (void)encodeWithCoder:(NSCoder *)coder {
-  [coder encodeObject:self.tOffset forKey:kMSToffsetKey];
+  [coder encodeObject:self.timestamp forKey:kMSTimestampKey];
   [coder encodeObject:self.device forKey:kMSDeviceKey];
 }
 

--- a/MobileCenter/MobileCenter/Internals/Device/MSDeviceTracker.m
+++ b/MobileCenter/MobileCenter/Internals/Device/MSDeviceTracker.m
@@ -210,7 +210,7 @@ static MSWrapperSdk *wrapperSdkInformation = nil;
       return self.deviceHistory[0].device;
     }
 
-    // All timestamp are smaller.
+    // All timestamps are smaller.
     else if (index == self.deviceHistory.count) {
       return [self.deviceHistory lastObject].device;
     }

--- a/MobileCenter/MobileCenter/Internals/Device/MSDeviceTrackerPrivate.h
+++ b/MobileCenter/MobileCenter/Internals/Device/MSDeviceTrackerPrivate.h
@@ -37,37 +37,37 @@ static NSString *const kMSPastDevicesKey = @"pastDevicesKey";
 - (void)clearDevices;
 
 /**
- *  Get the SDK version.
+ * Get the SDK version.
  *
- *  @param  version SDK version as const char.
+ * @param version SDK version as const char.
  *
- *  @return The SDK version as an NSString.
+ * @return The SDK version as an NSString.
  */
 - (NSString *)sdkVersion:(const char[])version;
 
 /**
- *  Get device model.
+ * Get device model.
  *
- *  @return The device model as an NSString.
+ * @return The device model as an NSString.
  */
 - (NSString *)deviceModel;
 
 #if TARGET_OS_OSX
 
 /**
- *  Get the OS name.
+ * Get the OS name.
  *
- *  @return The OS name as an NSString.
+ * @return The OS name as an NSString.
  */
 - (NSString *)osName;
 #else
 
 /**
- *  Get the OS name.
+ * Get the OS name.
  *
- *  @param device Current UIDevice.
+ * @param device Current UIDevice.
  *
- *  @return The OS name as an NSString.
+ * @return The OS name as an NSString.
  */
 - (NSString *)osName:(UIDevice *)device;
 #endif
@@ -75,93 +75,93 @@ static NSString *const kMSPastDevicesKey = @"pastDevicesKey";
 #if TARGET_OS_OSX
 
 /**
- *  Get the OS version.
+ * Get the OS version.
  *
- *  @return The OS version as an NSString.
+ * @return The OS version as an NSString.
  */
 - (NSString *)osVersion;
 #else
 
 /**
- *  Get the OS version.
+ * Get the OS version.
  *
- *  @param device Current UIDevice.
+ * @param device Current UIDevice.
  *
- *  @return The OS version as an NSString.
+ * @return The OS version as an NSString.
  */
 - (NSString *)osVersion:(UIDevice *)device;
 #endif
 
 /**
- *  Get the device current locale.
+ * Get the device current locale.
  *
- *  @param deviceLocale Device current locale.
+ * @param deviceLocale Device current locale.
  *
- *  @return The device current locale as an NSString.
+ * @return The device current locale as an NSString.
  */
 - (NSString *)locale:(NSLocale *)deviceLocale;
 
 /**
- *  Get the device current timezone offset (UTC as reference).
+ * Get the device current timezone offset (UTC as reference).
  *
- *  @param timeZone Device timezone.
+ * @param timeZone Device timezone.
  *
- *  @return The device current timezone offset as an NSNumber.
+ * @return The device current timezone offset as an NSNumber.
  */
 - (NSNumber *)timeZoneOffset:(NSTimeZone *)timeZone;
 
 /**
- *  Get the rendered screen size.
+ * Get the rendered screen size.
  *
- *  @return The size of the screen as an NSString with format "HEIGHTxWIDTH".
+ * @return The size of the screen as an NSString with format "HEIGHTxWIDTH".
  */
 - (NSString *)screenSize;
 
 #if TARGET_OS_IOS
 
 /**
- *  Get the network carrier name.
+ * Get the network carrier name.
  *
- *  @param carrier Network carrier.
+ * @param carrier Network carrier.
  *
- *  @return The network carrier name as an NSString.
+ * @return The network carrier name as an NSString.
  */
 - (NSString *)carrierName:(CTCarrier *)carrier;
 
 /**
- *  Get the network carrier country.
+ * Get the network carrier country.
  *
- *  @param carrier Network carrier.
+ * @param carrier Network carrier.
  *
- *  @return The network carrier country as an NSString.
+ * @return The network carrier country as an NSString.
  */
 - (NSString *)carrierCountry:(CTCarrier *)carrier;
 #endif
 
 /**
- *  Get the application version.
+ * Get the application version.
  *
- *  @param appBundle Application main bundle.
+ * @param appBundle Application main bundle.
  *
- *  @return The application version as an NSString.
+ * @return The application version as an NSString.
  */
 - (NSString *)appVersion:(NSBundle *)appBundle;
 
 /**
- *  Get the application build.
+ * Get the application build.
  *
- *  @param appBundle Application main bundle.
+ * @param appBundle Application main bundle.
  *
- *  @return The application build as an NSString.
+ * @return The application build as an NSString.
  */
 - (NSString *)appBuild:(NSBundle *)appBundle;
 
 /**
- *  Get the application bundle ID.
+ * Get the application bundle ID.
  *
- *  @param appBundle Application main bundle.
+ * @param appBundle Application main bundle.
  *
- *  @return The application bundle ID as an NSString.
+ * @return The application bundle ID as an NSString.
  */
 - (NSString *)appNamespace:(NSBundle *)appBundle;
 
@@ -173,7 +173,7 @@ static NSString *const kMSPastDevicesKey = @"pastDevicesKey";
 - (void)setWrapperSdk:(MSWrapperSdk *)wrapperSdk;
 
 /**
- *  Return a new Instance of MSDevice.
+ * Return a new Instance of MSDevice.
  *
  * @returns A new Instance of MSDevice. @see MSDevice
  *
@@ -184,13 +184,13 @@ static NSString *const kMSPastDevicesKey = @"pastDevicesKey";
 /**
  * Return a device from the history of past devices. This will be used e.g. for Crashes after relaunch.
  *
- * @param toffset Offset that will be used to find a matching MSDevice in history.
+ * @param timestamp Timestamp that will be used to find a matching MSDevice in history.
  *
- * @return Instance of MSDevice that's closest to tOffset.
+ * @return Instance of MSDevice that's closest to timestamp.
  *
- * @discussion If we cannot find a device that's within the range of the tOffset, the latest device from history will be
- * returned. If there is no history, we return the current MSDevice.
+ * @discussion If we cannot find a device that's within the range of the timestamp, the latest device from history will
+ * be returned. If there is no history, we return the current MSDevice.
  */
-- (MSDevice *)deviceForToffset:(NSNumber *)toffset;
+- (MSDevice *)deviceForTimestamp:(NSDate *)timestamp;
 
 @end

--- a/MobileCenter/MobileCenter/Internals/Model/MSAbstractLog.m
+++ b/MobileCenter/MobileCenter/Internals/Model/MSAbstractLog.m
@@ -5,14 +5,14 @@
 #import "MSUtility+Date.h"
 
 static NSString *const kMSSid = @"sid";
-static NSString *const kMSToffset = @"toffset";
+static NSString *const kMSTimestamp = @"timestamp";
 static NSString *const kMSDevice = @"device";
 static NSString *const kMSType = @"type";
 
 @implementation MSAbstractLog
 
 @synthesize type = _type;
-@synthesize toffset = _toffset;
+@synthesize timestamp = _timestamp;
 @synthesize sid = _sid;
 @synthesize device = _device;
 
@@ -22,12 +22,8 @@ static NSString *const kMSType = @"type";
   if (self.type) {
     dict[kMSType] = self.type;
   }
-  if (self.toffset) {
-
-    // Set the toffset relative to current time. The toffset needs to be up to date.
-    long long now = (long long)[MSUtility nowInMilliseconds];
-    long long relativeTime = now - [self.toffset longLongValue];
-    dict[kMSToffset] = @(relativeTime);
+  if (self.timestamp) {
+    dict[kMSTimestamp] = [MSUtility dateToISO8601:self.timestamp];
   }
   if (self.sid) {
     dict[kMSSid] = self.sid;
@@ -39,7 +35,7 @@ static NSString *const kMSType = @"type";
 }
 
 - (BOOL)isValid {
-  return self.type && self.toffset && self.device && [self.device isValid];
+  return self.type && self.timestamp && self.device && [self.device isValid];
 }
 
 - (BOOL)isEqual:(id)object {
@@ -48,7 +44,7 @@ static NSString *const kMSType = @"type";
   }
   MSAbstractLog *log = (MSAbstractLog *)object;
   return ((!self.type && !log.type) || [self.type isEqualToString:log.type]) &&
-         ((!self.toffset && !log.toffset) || [self.toffset isEqualToNumber:log.toffset]) &&
+         ((!self.timestamp && !log.timestamp) || [self.timestamp isEqualToDate:log.timestamp]) &&
          ((!self.sid && !log.sid) || [self.sid isEqualToString:log.sid]) &&
          ((!self.device && !log.device) || [self.device isEqual:log.device]);
 }
@@ -59,7 +55,7 @@ static NSString *const kMSType = @"type";
   self = [super init];
   if (self) {
     _type = [coder decodeObjectForKey:kMSType];
-    _toffset = [coder decodeObjectForKey:kMSToffset];
+    _timestamp = [coder decodeObjectForKey:kMSTimestamp];
     _sid = [coder decodeObjectForKey:kMSSid];
     _device = [coder decodeObjectForKey:kMSDevice];
   }
@@ -68,7 +64,7 @@ static NSString *const kMSType = @"type";
 
 - (void)encodeWithCoder:(NSCoder *)coder {
   [coder encodeObject:self.type forKey:kMSType];
-  [coder encodeObject:self.toffset forKey:kMSToffset];
+  [coder encodeObject:self.timestamp forKey:kMSTimestamp];
   [coder encodeObject:self.sid forKey:kMSSid];
   [coder encodeObject:self.device forKey:kMSDevice];
 }

--- a/MobileCenter/MobileCenter/Internals/Model/MSCustomPropertiesLog.m
+++ b/MobileCenter/MobileCenter/Internals/Model/MSCustomPropertiesLog.m
@@ -1,4 +1,5 @@
 #import "MSCustomPropertiesLog.h"
+#import "MSUtility+Date.h"
 
 static NSString *const kMSCustomProperties = @"custom_properties";
 static NSString *const kMSProperties = @"properties";
@@ -77,15 +78,8 @@ static NSString *const kMSPropertyTypeString = @"string";
       [property setObject:value forKey:kMSPropertyValue];
     }
   } else if ([value isKindOfClass:[NSDate class]]) {
-    static NSDateFormatter *dateFormatter = nil;
-    if (!dateFormatter) {
-      dateFormatter = [[NSDateFormatter alloc] init];
-      [dateFormatter setLocale:[NSLocale systemLocale]];
-      [dateFormatter setTimeZone:[NSTimeZone timeZoneWithAbbreviation: @"UTC"]];
-      [dateFormatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ss'Z'"];
-    }
     [property setObject:kMSPropertyTypeDateTime forKey:kMSPropertyType];
-    [property setObject:[dateFormatter stringFromDate:(NSDate *)value] forKey:kMSPropertyValue];
+    [property setObject:[MSUtility dateToISO8601:(NSDate *)value] forKey:kMSPropertyValue];
   } else if ([value isKindOfClass:[NSString class]]) {
     [property setObject:kMSPropertyTypeString forKey:kMSPropertyType];
     [property setObject:value forKey:kMSPropertyValue];

--- a/MobileCenter/MobileCenter/Internals/Model/MSLog.h
+++ b/MobileCenter/MobileCenter/Internals/Model/MSLog.h
@@ -10,10 +10,9 @@
 @property(nonatomic, copy) NSString *type;
 
 /**
- * Corresponds to the number of milliseconds elapsed between the time the
- * request is sent and the time the log is emitted.
+ * Log timestamp.
  */
-@property(nonatomic) NSNumber *toffset;
+@property(nonatomic) NSDate *timestamp;
 
 /**
  * A session identifier is used to correlate logs together. A session is an abstract concept in the API and

--- a/MobileCenter/MobileCenter/Internals/Util/MSUtility+Date.h
+++ b/MobileCenter/MobileCenter/Internals/Util/MSUtility+Date.h
@@ -18,10 +18,17 @@ extern NSString *MSUtilityDateCategory;
  * @return current time in ms with sub-ms precision if necessary
  *
  * @discussion
- * Utility function that returns NOW as a NSTimeInterval but in ms instead of seconds with sub-ms precision. We're using NSTimeInterval
- * here instead of long long because we might be interested in sub-millisecond precision which we keep with NSTimeInterval as NSTimeInterval
- * is actually NSDouble.
+ * Utility function that returns NOW as a NSTimeInterval but in ms instead of seconds with sub-ms precision. We're using
+ * NSTimeInterval here instead of long long because we might be interested in sub-millisecond precision which we keep
+ * with NSTimeInterval as NSTimeInterval is actually NSDouble.
  */
 + (NSTimeInterval)nowInMilliseconds;
+
+/**
+ * Convert a date object to an ISO 8601 formatted string.
+ *
+ * @return an ISO 8601 string representation of the date.
+ */
++ (NSString *)dateToISO8601:(NSDate *)date;
 
 @end

--- a/MobileCenter/MobileCenter/Internals/Util/MSUtility+Date.m
+++ b/MobileCenter/MobileCenter/Internals/Util/MSUtility+Date.m
@@ -8,7 +8,18 @@ NSString *MSUtilityDateCategory;
 @implementation MSUtility (Date)
 
 + (NSTimeInterval)nowInMilliseconds {
-    return ([[NSDate date] timeIntervalSince1970] * 1000);
+  return ([[NSDate date] timeIntervalSince1970] * 1000);
+}
+
++ (NSString *)dateToISO8601:(NSDate *)date {
+  static NSDateFormatter *dateFormatter = nil;
+  if (!dateFormatter) {
+    dateFormatter = [[NSDateFormatter alloc] init];
+    [dateFormatter setLocale:[NSLocale systemLocale]];
+    [dateFormatter setTimeZone:[NSTimeZone timeZoneWithAbbreviation:@"UTC"]];
+    [dateFormatter setDateFormat:@"yyyy-MM-dd'T'HH:mm:ss'Z'"];
+  }
+  return [dateFormatter stringFromDate:date];
 }
 
 @end

--- a/MobileCenter/MobileCenterTests/MSChannelDefaultTests.m
+++ b/MobileCenter/MobileCenterTests/MSChannelDefaultTests.m
@@ -147,7 +147,7 @@ static NSString *const kMSTestGroupId = @"GroupId";
                                  assertThat(logContainer.batchId, is(expectedBatchId));
                                  assertThat(logContainer.logs, is(@[ expectedLog ]));
                                  assertThatBool(sut.pendingBatchQueueFull, isFalse());
-                                 assertThatUnsignedInt(sut.pendingBatchIds.count, equalToInt(0));
+                                 assertThatUnsignedLong(sut.pendingBatchIds.count, equalToUnsignedLong(0));
                                  OCMVerifyAll(delegateMock);
                                  OCMVerifyAll(storageMock);
                                  if (error) {
@@ -236,7 +236,7 @@ static NSString *const kMSTestGroupId = @"GroupId";
                                  assertThat(logContainer.batchId, is(expectedBatchId));
                                  assertThat(logContainer.logs, is(@[ expectedLog ]));
                                  assertThatBool(sut.pendingBatchQueueFull, isFalse());
-                                 assertThatUnsignedInt(sut.pendingBatchIds.count, equalToInt(0));
+                                 assertThatUnsignedLong(sut.pendingBatchIds.count, equalToUnsignedLong(0));
                                  OCMVerifyAll(delegateMock);
                                  OCMVerifyAll(storageMock);
                                  if (error) {

--- a/MobileCenter/MobileCenterTests/MSCustomPropertiesLogTests.m
+++ b/MobileCenter/MobileCenterTests/MSCustomPropertiesLogTests.m
@@ -92,7 +92,7 @@
   // If
   self.sut.device = OCMClassMock([MSDevice class]);
   OCMStub([self.sut.device isValid]).andReturn(YES);
-  self.sut.toffset = @(3);
+  self.sut.timestamp = [NSDate dateWithTimeIntervalSince1970:42];
   self.sut.sid = @"1234567890";
   
   // When

--- a/MobileCenter/MobileCenterTests/MSDeviceHistoryInfoTests.m
+++ b/MobileCenter/MobileCenterTests/MSDeviceHistoryInfoTests.m
@@ -18,13 +18,14 @@
   XCTAssertNotNil(expected);
   
   // When
+  NSDate *timestamp = [NSDate dateWithTimeIntervalSince1970:42];
   MSDevice *aDevice = [MSDevice new];
-  expected = [[MSDeviceHistoryInfo alloc] initWithTOffset:@1 andDevice:aDevice];
+  expected = [[MSDeviceHistoryInfo alloc] initWithTimestamp:timestamp andDevice:aDevice];
   
   // Then
   XCTAssertNotNil(expected);
+  XCTAssertTrue([expected.timestamp isEqual:timestamp]);
   XCTAssertTrue([expected.device isEqual:aDevice]);
-  XCTAssertTrue([expected.tOffset isEqualToNumber:@1]);
 }
 
 @end

--- a/MobileCenter/MobileCenterTests/MSDeviceTrackerTests.m
+++ b/MobileCenter/MobileCenterTests/MSDeviceTrackerTests.m
@@ -457,7 +457,7 @@ static NSString *const kMSDeviceManufacturerTest = @"Apple";
   [tracker clearDevices];
 
   // When
-  MSDevice *actual = [tracker deviceForToffset:@1];
+  MSDevice *actual = [tracker deviceForTimestamp:[NSDate dateWithTimeIntervalSince1970:1]];
 
   // Then
   XCTAssertTrue([actual isEqual:tracker.device]);
@@ -471,14 +471,13 @@ static NSString *const kMSDeviceManufacturerTest = @"Apple";
   MSDevice *third = [tracker device];
 
   // When
-  actual = [tracker deviceForToffset:@1];
+  actual = [tracker deviceForTimestamp:[NSDate dateWithTimeIntervalSince1970:1]];
 
   // Then
   XCTAssertTrue([actual isEqual:first]);
 
   // When
-  NSNumber *now = [NSNumber numberWithLongLong:(long long)([MSUtility nowInMilliseconds])];
-  actual = [tracker deviceForToffset:now];
+  actual = [tracker deviceForTimestamp:[NSDate date]];
 
   // Then
   XCTAssertTrue([actual isEqual:third]);

--- a/MobileCenter/MobileCenterTests/MSIngestionSenderTests.m
+++ b/MobileCenter/MobileCenterTests/MSIngestionSenderTests.m
@@ -393,7 +393,7 @@ static NSString *const kMSBaseUrl = @"https://test.com";
 
   MSAbstractLog *log = [MSAbstractLog new];
   log.sid = MS_UUID_STRING;
-  log.toffset = [NSNumber numberWithLongLong:(long long)([MSUtility nowInMilliseconds])];
+  log.timestamp = [NSDate date];
 
   // Log does not have device info, therefore, it's an invalid log
   MSLogContainer *container = [[MSLogContainer alloc] initWithBatchId:@"1" andLogs:(NSArray<id<MSLog>> *)@[ log ]];
@@ -649,12 +649,12 @@ static NSString *const kMSBaseUrl = @"https://test.com";
 
   MSMockLog *log1 = [[MSMockLog alloc] init];
   log1.sid = MS_UUID_STRING;
-  log1.toffset = [NSNumber numberWithLongLong:(long long)([MSUtility nowInMilliseconds])];
+  log1.timestamp = [NSDate date];
   log1.device = deviceMock;
 
   MSMockLog *log2 = [[MSMockLog alloc] init];
   log2.sid = MS_UUID_STRING;
-  log2.toffset = [NSNumber numberWithLongLong:(long long)([MSUtility nowInMilliseconds])];
+  log2.timestamp = [NSDate date];
   log2.device = deviceMock;
 
   MSLogContainer *logContainer =

--- a/MobileCenter/MobileCenterTests/MSLogContainerTests.m
+++ b/MobileCenter/MobileCenterTests/MSLogContainerTests.m
@@ -16,11 +16,11 @@
 
   MSAbstractLog *log1 = [MSAbstractLog new];
   log1.sid = MS_UUID_STRING;
-  log1.toffset = [NSNumber numberWithLongLong:(long long)([MSUtility nowInMilliseconds])];
+  log1.timestamp = [NSDate date];
 
   MSAbstractLog *log2 = [MSAbstractLog new];
   log2.sid = MS_UUID_STRING;
-  log2.toffset = [NSNumber numberWithLongLong:(long long)([MSUtility nowInMilliseconds])];
+  log2.timestamp = [NSDate date];
 
   logContainer.logs = (NSArray<id<MSLog>> *)@[ log1, log2 ];
 

--- a/MobileCenterAnalytics/MobileCenterAnalytics/Internals/Session/MSSessionHistoryInfo.h
+++ b/MobileCenterAnalytics/MobileCenterAnalytics/Internals/Session/MSSessionHistoryInfo.h
@@ -5,10 +5,10 @@
 /**
  * Initializes a new `MSSessionHistoryInfo` instance.
  *
- * @param toffset Time offset
+ * @param timestamp Timestamp
  * @param sessionId Session Id
  */
-- (instancetype)initWithTOffset:(NSNumber *)toffset andSessionId:(NSString *)sessionId;
+- (instancetype)initWithTimestamp:(NSDate *)timestamp andSessionId:(NSString *)sessionId;
 
 /**
  *  Session Id.
@@ -16,8 +16,8 @@
 @property(nonatomic, copy) NSString *sessionId;
 
 /**
- *  Time offset.
+ *  Timestamp.
  */
-@property(nonatomic) NSNumber *toffset;
+@property(nonatomic) NSDate *timestamp;
 
 @end

--- a/MobileCenterAnalytics/MobileCenterAnalytics/Internals/Session/MSSessionHistoryInfo.m
+++ b/MobileCenterAnalytics/MobileCenterAnalytics/Internals/Session/MSSessionHistoryInfo.m
@@ -1,7 +1,7 @@
 #import "MSSessionHistoryInfo.h"
 
 static NSString *const kMSSessionIdKey = @"sessionIdKey";
-static NSString *const kMSToffsetKey = @"toffsetKey";
+static NSString *const kMSTimestampKey = @"timestampKey";
 
 /**
  * This class is used to associate session id with the timestamp that it was created.
@@ -12,21 +12,21 @@ static NSString *const kMSToffsetKey = @"toffsetKey";
   self = [super init];
   if (self) {
     _sessionId = [coder decodeObjectForKey:kMSSessionIdKey];
-    _toffset = [coder decodeObjectForKey:kMSToffsetKey];
+    _timestamp = [coder decodeObjectForKey:kMSTimestampKey];
   }
   return self;
 }
 
 - (void)encodeWithCoder:(NSCoder *)coder {
   [coder encodeObject:self.sessionId forKey:kMSSessionIdKey];
-  [coder encodeObject:self.toffset forKey:kMSToffsetKey];
+  [coder encodeObject:self.timestamp forKey:kMSTimestampKey];
 }
 
-- (instancetype)initWithTOffset:(NSNumber *)toffset andSessionId:(NSString *)sessionId {
+- (instancetype)initWithTimestamp:(NSDate *)timestamp andSessionId:(NSString *)sessionId {
   self = [super init];
   if (self) {
     _sessionId = sessionId;
-    _toffset = toffset;
+    _timestamp = timestamp;
   }
   return self;
 }

--- a/MobileCenterAnalytics/MobileCenterAnalytics/Internals/Session/MSSessionTracker.m
+++ b/MobileCenterAnalytics/MobileCenterAnalytics/Internals/Session/MSSessionTracker.m
@@ -65,14 +65,14 @@ static NSUInteger const kMSMaxSessionHistoryCount = 5;
       // Record session.
       MSSessionHistoryInfo *sessionInfo = [[MSSessionHistoryInfo alloc] init];
       sessionInfo.sessionId = _sessionId;
-      sessionInfo.toffset = [NSNumber numberWithDouble:[MSUtility nowInMilliseconds]];
+      sessionInfo.timestamp = [NSDate date];
 
       // Insert new MSSessionHistoryInfo at the proper index to keep pastSessions sorted.
       NSUInteger newIndex = [self.pastSessions indexOfObject:sessionInfo
           inSortedRange:(NSRange) { 0, [self.pastSessions count] }
           options:NSBinarySearchingInsertionIndex
-          usingComparator:^(id a, id b) {
-            return [((MSSessionHistoryInfo *)a).toffset compare:((MSSessionHistoryInfo *)b).toffset];
+          usingComparator:^(MSSessionHistoryInfo *a, MSSessionHistoryInfo *b) {
+            return [a.timestamp compare:b.timestamp];
           }];
       [self.pastSessions insertObject:sessionInfo atIndex:newIndex];
 
@@ -200,27 +200,27 @@ static NSUInteger const kMSMaxSessionHistoryCount = 5;
     return;
 
   // Attach corresponding session id.
-  if (log.toffset) {
-    MSSessionHistoryInfo *find = [[MSSessionHistoryInfo alloc] initWithTOffset:log.toffset andSessionId:nil];
+  if (log.timestamp) {
+    MSSessionHistoryInfo *find = [[MSSessionHistoryInfo alloc] initWithTimestamp:log.timestamp andSessionId:nil];
     NSUInteger index =
         [self.pastSessions indexOfObject:find
                            inSortedRange:NSMakeRange(0, self.pastSessions.count)
                                  options:(NSBinarySearchingFirstEqual | NSBinarySearchingInsertionIndex)
-                         usingComparator:^(id a, id b) {
-                           return [((MSSessionHistoryInfo *)a).toffset compare:((MSSessionHistoryInfo *)b).toffset];
+                         usingComparator:^(MSSessionHistoryInfo *a, MSSessionHistoryInfo *b) {
+                           return [a.timestamp compare:b.timestamp];
                          }];
 
-    // All toffsets are larger.
+    // All timestamp are larger.
     if (index == 0) {
       log.sid = self.sessionId;
     }
 
-    // All toffsets are smaller.
+    // All timestamp are smaller.
     else if (index == self.pastSessions.count) {
       log.sid = [self.pastSessions lastObject].sessionId;
     }
 
-    // [index - 1] should be the right index for the toffset.
+    // [index - 1] should be the right index for the timestamp.
     else {
       log.sid = self.pastSessions[index - 1].sessionId;
     }

--- a/MobileCenterAnalytics/MobileCenterAnalytics/Internals/Session/MSSessionTracker.m
+++ b/MobileCenterAnalytics/MobileCenterAnalytics/Internals/Session/MSSessionTracker.m
@@ -210,12 +210,12 @@ static NSUInteger const kMSMaxSessionHistoryCount = 5;
                            return [a.timestamp compare:b.timestamp];
                          }];
 
-    // All timestamp are larger.
+    // All timestamps are larger.
     if (index == 0) {
       log.sid = self.sessionId;
     }
 
-    // All timestamp are smaller.
+    // All timestamps are smaller.
     else if (index == self.pastSessions.count) {
       log.sid = [self.pastSessions lastObject].sessionId;
     }

--- a/MobileCenterAnalytics/MobileCenterAnalyticsTests/MSEventLogTests.m
+++ b/MobileCenterAnalytics/MobileCenterAnalyticsTests/MSEventLogTests.m
@@ -31,13 +31,12 @@
   MSDevice *device = [MSDevice new];
   NSString *sessionId = @"1234567890";
   NSDictionary *properties = @{ @"Key" : @"Value" };
-  long long createTime = (long long)[MSUtility nowInMilliseconds];
-  NSNumber *tOffset = @(createTime);
+  NSDate *timestamp = [NSDate dateWithTimeIntervalSince1970:42];
 
   self.sut.eventId = eventId;
   self.sut.name = eventName;
   self.sut.device = device;
-  self.sut.toffset = tOffset;
+  self.sut.timestamp = timestamp;
   self.sut.sid = sessionId;
   self.sut.properties = properties;
 
@@ -53,9 +52,7 @@
   assertThat(actual[@"type"], equalTo(typeName));
   assertThat(actual[@"properties"], equalTo(properties));
   assertThat(actual[@"device"], notNilValue());
-  NSTimeInterval seralizedToffset = [actual[@"toffset"] longLongValue];
-  NSTimeInterval actualToffset = [MSUtility nowInMilliseconds] - createTime;
-  assertThat(@(seralizedToffset), lessThan(@(actualToffset)));
+  assertThat(actual[@"timestamp"], equalTo(@"1970-01-01T00:00:42Z"));
 }
 
 - (void)testNSCodingSerializationAndDeserializationWorks {
@@ -66,13 +63,13 @@
   NSString *eventName = @"eventName";
   MSDevice *device = [MSDevice new];
   NSString *sessionId = @"1234567890";
-  NSNumber *tOffset = @(3);
+  NSDate *timestamp = [NSDate dateWithTimeIntervalSince1970:42];
   NSDictionary *properties = @{ @"Key" : @"Value" };
 
   self.sut.eventId = eventId;
   self.sut.name = eventName;
   self.sut.device = device;
-  self.sut.toffset = tOffset;
+  self.sut.timestamp = timestamp;
   self.sut.sid = sessionId;
   self.sut.properties = properties;
 
@@ -87,7 +84,7 @@
   assertThat(actualEvent.name, equalTo(eventName));
   assertThat(actualEvent.eventId, equalTo(eventId));
   assertThat(actualEvent.device, notNilValue());
-  assertThat(actualEvent.toffset, equalTo(tOffset));
+  assertThat(actualEvent.timestamp, equalTo(timestamp));
   assertThat(actualEvent.type, equalTo(typeName));
   assertThat(actualEvent.sid, equalTo(sessionId));
   assertThat(actualEvent.properties, equalTo(properties));
@@ -99,7 +96,7 @@
   // If
   self.sut.device = OCMClassMock([MSDevice class]);
   OCMStub([self.sut.device isValid]).andReturn(YES);
-  self.sut.toffset = @(3);
+  self.sut.timestamp = [NSDate dateWithTimeIntervalSince1970:42];
   self.sut.sid = @"1234567890";
 
   // Then

--- a/MobileCenterAnalytics/MobileCenterAnalyticsTests/MSPageLogTests.m
+++ b/MobileCenterAnalytics/MobileCenterAnalyticsTests/MSPageLogTests.m
@@ -30,12 +30,11 @@
   MSDevice *device = [MSDevice new];
   NSString *sessionId = @"1234567890";
   NSDictionary *properties = @{ @"Key" : @"Value" };
-  long long createTime = (long long)[MSUtility nowInMilliseconds];
-  NSNumber *tOffset = [NSNumber numberWithLongLong:createTime];
+  NSDate *timestamp = [NSDate dateWithTimeIntervalSince1970:42];
 
   self.sut.name = pageName;
   self.sut.device = device;
-  self.sut.toffset = tOffset;
+  self.sut.timestamp = timestamp;
   self.sut.sid = sessionId;
   self.sut.properties = properties;
 
@@ -50,9 +49,7 @@
   assertThat(actual[@"type"], equalTo(typeName));
   assertThat(actual[@"properties"], equalTo(properties));
   assertThat(actual[@"device"], notNilValue());
-  NSTimeInterval seralizedToffset = [actual[@"toffset"] longLongValue];
-  NSTimeInterval actualToffset = [MSUtility nowInMilliseconds] - createTime;
-  assertThat(@(seralizedToffset), lessThan(@(actualToffset)));
+  assertThat(actual[@"timestamp"], equalTo(@"1970-01-01T00:00:42Z"));
 }
 
 - (void)testNSCodingSerializationAndDeserializationWorks {
@@ -62,12 +59,12 @@
   NSString *pageName = @"pageName";
   MSDevice *device = [MSDevice new];
   NSString *sessionId = @"1234567890";
-  NSNumber *tOffset = @(3);
+  NSDate *timestamp = [NSDate dateWithTimeIntervalSince1970:42];
   NSDictionary *properties = @{ @"Key" : @"Value" };
 
   self.sut.name = pageName;
   self.sut.device = device;
-  self.sut.toffset = tOffset;
+  self.sut.timestamp = timestamp;
   self.sut.sid = sessionId;
   self.sut.properties = properties;
 
@@ -81,7 +78,7 @@
   MSPageLog *actualPage = actual;
   assertThat(actualPage.name, equalTo(pageName));
   assertThat(actualPage.device, notNilValue());
-  assertThat(actualPage.toffset, equalTo(tOffset));
+  assertThat(actualPage.timestamp, equalTo(timestamp));
   assertThat(actualPage.type, equalTo(typeName));
   assertThat(actualPage.sid, equalTo(sessionId));
   assertThat(actualPage.properties, equalTo(properties));
@@ -93,7 +90,7 @@
   // If
   self.sut.device = OCMClassMock([MSDevice class]);
   OCMStub([self.sut.device isValid]).andReturn(YES);
-  self.sut.toffset = @(3);
+  self.sut.timestamp = [NSDate dateWithTimeIntervalSince1970:42];
   self.sut.sid = @"1234567890";
 
   // Then

--- a/MobileCenterAnalytics/MobileCenterAnalyticsTests/MSSessionTrackerTests.m
+++ b/MobileCenterAnalytics/MobileCenterAnalyticsTests/MSSessionTrackerTests.m
@@ -205,29 +205,22 @@ static NSTimeInterval const kMSTestSessionTimeout = 1.5;
 
   // Then
   XCTAssertNil(log.sid);
-  XCTAssertNil(log.toffset);
+  XCTAssertNil(log.timestamp);
 
   // When
   [self.sut onEnqueuingLog:log withInternalId:nil];
 
   // Then
-  XCTAssertNil(log.toffset);
+  XCTAssertNil(log.timestamp);
   XCTAssertEqual(log.sid, self.sut.sessionId);
 
   // When
-  log.toffset = 0;
+  NSDate *timestamp = [NSDate dateWithTimeIntervalSince1970:42];
+  log.timestamp = timestamp;
   [self.sut onEnqueuingLog:log withInternalId:nil];
 
   // Then
-  XCTAssertEqual(0, log.toffset.integerValue);
-  XCTAssertEqual(log.sid, [self.sut.pastSessions lastObject].sessionId);
-
-  // When
-  log.toffset = [NSNumber numberWithUnsignedLongLong:UINT64_MAX];
-  [self.sut onEnqueuingLog:log withInternalId:nil];
-
-  // Then
-  XCTAssertEqual(UINT64_MAX, log.toffset.unsignedLongLongValue);
+  XCTAssertEqual(timestamp, log.timestamp);
   XCTAssertEqual(log.sid, [self.sut.pastSessions lastObject].sessionId);
 }
 
@@ -238,13 +231,13 @@ static NSTimeInterval const kMSTestSessionTimeout = 1.5;
 
   // Then
   XCTAssertNil(log.sid);
-  XCTAssertNil(log.toffset);
+  XCTAssertNil(log.timestamp);
 
   // When
   [self.sut onEnqueuingLog:log withInternalId:nil];
 
   // Then
-  XCTAssertNil(log.toffset);
+  XCTAssertNil(log.timestamp);
   XCTAssertEqual(log.sid, self.sut.sessionId);
 
   // If
@@ -252,13 +245,13 @@ static NSTimeInterval const kMSTestSessionTimeout = 1.5;
 
   // Then
   XCTAssertNil(sessionLog.sid);
-  XCTAssertNil(sessionLog.toffset);
+  XCTAssertNil(sessionLog.timestamp);
 
   // When
   [self.sut onEnqueuingLog:sessionLog withInternalId:nil];
 
   // Then
-  XCTAssertNil(sessionLog.toffset);
+  XCTAssertNil(sessionLog.timestamp);
   XCTAssertNil(sessionLog.sid);
 
   // If
@@ -266,13 +259,13 @@ static NSTimeInterval const kMSTestSessionTimeout = 1.5;
 
   // Then
   XCTAssertNil(serviceLog.sid);
-  XCTAssertNil(serviceLog.toffset);
+  XCTAssertNil(serviceLog.timestamp);
 
   // When
   [self.sut onEnqueuingLog:serviceLog withInternalId:nil];
 
   // Then
-  XCTAssertNil(serviceLog.toffset);
+  XCTAssertNil(serviceLog.timestamp);
   XCTAssertNil(serviceLog.sid);
 }
 

--- a/MobileCenterAnalytics/MobileCenterAnalyticsTests/MSStartSessionLogTests.m
+++ b/MobileCenterAnalytics/MobileCenterAnalyticsTests/MSStartSessionLogTests.m
@@ -28,11 +28,10 @@
   MSDevice *device = [MSDevice new];
   NSString *typeName = @"start_session";
   NSString *sessionId = @"1234567890";
-  long long createTime = (long long)[MSUtility nowInMilliseconds];
-  NSNumber *tOffset = @(createTime);
+  NSDate *timestamp = [NSDate dateWithTimeIntervalSince1970:42];
 
   self.sut.device = device;
-  self.sut.toffset = tOffset;
+  self.sut.timestamp = timestamp;
   self.sut.sid = sessionId;
 
   // When
@@ -42,9 +41,7 @@
   assertThat(actual, notNilValue());
   assertThat(actual[@"type"], equalTo(typeName));
   assertThat(actual[@"device"], notNilValue());
-  NSTimeInterval seralizedToffset = [actual[@"toffset"] longLongValue];
-  NSTimeInterval actualToffset = [MSUtility nowInMilliseconds] - createTime;
-  assertThat(@(seralizedToffset), lessThan(@(actualToffset)));
+  assertThat(actual[@"timestamp"], equalTo(@"1970-01-01T00:00:42Z"));
 }
 
 - (void)testNSCodingSerializationAndDeserializationWorks {
@@ -53,10 +50,10 @@
   MSDevice *device = [MSDevice new];
   NSString *typeName = @"start_session";
   NSString *sessionId = @"1234567890";
-  NSNumber *tOffset = @(3);
+  NSDate *timestamp = [NSDate dateWithTimeIntervalSince1970:42];
 
   self.sut.device = device;
-  self.sut.toffset = tOffset;
+  self.sut.timestamp = timestamp;
   self.sut.sid = sessionId;
 
   // When
@@ -69,7 +66,7 @@
 
   MSStartSessionLog *actualSession = actual;
   assertThat(actualSession.device, notNilValue());
-  assertThat(actualSession.toffset, equalTo(tOffset));
+  assertThat(actualSession.timestamp, equalTo(timestamp));
   assertThat(actualSession.type, equalTo(typeName));
   assertThat(actualSession.sid, equalTo(sessionId));
 }

--- a/MobileCenterCrashes/MobileCenterCrashes/Internals/Model/MSAbstractErrorLog.h
+++ b/MobileCenterCrashes/MobileCenterCrashes/Internals/Model/MSAbstractErrorLog.h
@@ -48,9 +48,9 @@
 @property(nonatomic) BOOL fatal;
 
 /*
- * Corresponds to the number of milliseconds elapsed between the time the error occurred and the app was launched.
+ * Timestamp when the app was launched.
  */
-@property(nonatomic) NSNumber *appLaunchTOffset;
+@property(nonatomic) NSDate *appLaunchTimestamp;
 
 /*
  * CPU Architecture. [optional]

--- a/MobileCenterCrashes/MobileCenterCrashes/Internals/Model/MSAbstractErrorLog.m
+++ b/MobileCenterCrashes/MobileCenterCrashes/Internals/Model/MSAbstractErrorLog.m
@@ -8,7 +8,7 @@ static NSString *const kMSParentProcessName = @"parent_process_name";
 static NSString *const kMSErrorThreadId = @"error_thread_id";
 static NSString *const kMSErrorThreadName = @"error_thread_name";
 static NSString *const kMSFatal = @"fatal";
-static NSString *const kMSAppLaunchTOffset = @"app_launch_toffset";
+static NSString *const kMSAppLaunchTimestamp = @"app_launch_timestamp";
 static NSString *const kMSArchitecture = @"architecture";
 
 @implementation MSAbstractErrorLog
@@ -21,7 +21,7 @@ static NSString *const kMSArchitecture = @"architecture";
 @synthesize errorThreadId = _errorThreadId;
 @synthesize errorThreadName = _errorThreadName;
 @synthesize fatal = _fatal;
-@synthesize appLaunchTOffset = _appLaunchTOffset;
+@synthesize appLaunchTimestamp = _appLaunchTimestamp;
 @synthesize architecture = _architecture;
 
 - (NSMutableDictionary *)serializeToDictionary {
@@ -49,8 +49,8 @@ static NSString *const kMSArchitecture = @"architecture";
     dict[kMSErrorThreadName] = self.errorThreadName;
   }
   dict[kMSFatal] = self.fatal ? @YES : @NO;
-  if (self.appLaunchTOffset) {
-    dict[kMSAppLaunchTOffset] = self.appLaunchTOffset;
+  if (self.appLaunchTimestamp) {
+    dict[kMSAppLaunchTimestamp] = [MSUtility dateToISO8601:self.appLaunchTimestamp];
   }
   if (self.architecture) {
     dict[kMSArchitecture] = self.architecture;
@@ -78,8 +78,8 @@ static NSString *const kMSArchitecture = @"architecture";
          ((!self.errorThreadId && !errorLog.errorThreadId) || [self.errorThreadId isEqual:errorLog.errorThreadId]) &&
          ((!self.errorThreadName && !errorLog.errorThreadName) ||
           [self.errorThreadName isEqualToString:errorLog.errorThreadName]) &&
-         (self.fatal == errorLog.fatal) && ((!self.appLaunchTOffset && !errorLog.appLaunchTOffset) ||
-                                            [self.appLaunchTOffset isEqual:errorLog.appLaunchTOffset]) &&
+         (self.fatal == errorLog.fatal) && ((!self.appLaunchTimestamp && !errorLog.appLaunchTimestamp) ||
+                                            [self.appLaunchTimestamp isEqual:errorLog.appLaunchTimestamp]) &&
          ((!self.architecture && !errorLog.architecture) || [self.architecture isEqualToString:errorLog.architecture]);
 }
 
@@ -96,7 +96,7 @@ static NSString *const kMSArchitecture = @"architecture";
     _errorThreadId = [coder decodeObjectForKey:kMSErrorThreadId];
     _errorThreadName = [coder decodeObjectForKey:kMSErrorThreadName];
     _fatal = [coder decodeBoolForKey:kMSFatal];
-    _appLaunchTOffset = [coder decodeObjectForKey:kMSAppLaunchTOffset];
+    _appLaunchTimestamp = [coder decodeObjectForKey:kMSAppLaunchTimestamp];
     _architecture = [coder decodeObjectForKey:kMSArchitecture];
   }
   return self;
@@ -112,7 +112,7 @@ static NSString *const kMSArchitecture = @"architecture";
   [coder encodeObject:self.errorThreadId forKey:kMSErrorThreadId];
   [coder encodeObject:self.errorThreadName forKey:kMSErrorThreadName];
   [coder encodeBool:self.fatal forKey:kMSFatal];
-  [coder encodeObject:self.appLaunchTOffset forKey:kMSAppLaunchTOffset];
+  [coder encodeObject:self.appLaunchTimestamp forKey:kMSAppLaunchTimestamp];
   [coder encodeObject:self.architecture forKey:kMSArchitecture];
 }
 

--- a/MobileCenterCrashes/MobileCenterCrashes/Internals/Util/MSErrorLogFormatter.m
+++ b/MobileCenterCrashes/MobileCenterCrashes/Internals/Util/MSErrorLogFormatter.m
@@ -219,14 +219,9 @@ static const char *findSEL(const char *imageName, NSString *imageUUID, uint64_t 
   // All errors are fatal for now, until we add support for handled exceptions.
   errorLog.fatal = YES;
 
-  /*
-   * appLaunchTOffset - the difference between crashtime and initialization time, so the "age" of the crashreport before
-   * it's forwarded to the channel.
-   * We don't care about a negative difference (will happen if the user's time on the device changes to a time before
-   * the crashTime and the time the error is processed).
-   */
-  errorLog.appLaunchTOffset = [self calculateAppLaunchTOffsetFromReport:report];
-  errorLog.toffset = [self calculateTOffsetFromReport:report];
+  // Application launch and crash timestamps
+  errorLog.appLaunchTimestamp = [self getAppLaunchTimeFromReport:report];
+  errorLog.timestamp = [self getCrashTimeFromReport:report];
 
   // CPU Type and Subtype for the crash. We need to query the binary images for that.
   NSArray *images = report.images;
@@ -271,10 +266,11 @@ static const char *findSEL(const char *imageName, NSString *imageUUID, uint64_t 
    * Set the device here to make sure we don't use the current device information but the one from history that matches
    * the time of our crash.
    */
-  errorLog.device = [[MSDeviceTracker new] deviceForToffset:errorLog.toffset];
+  errorLog.device = [[MSDeviceTracker new] deviceForTimestamp:errorLog.timestamp];
 
   // Set the exception from the wrapper SDK.
-  MSWrapperException* wrapperException = [MSWrapperExceptionManager loadWrapperExceptionWithUUIDString:[self uuidRefToString:report.uuidRef]];
+  MSWrapperException *wrapperException =
+      [MSWrapperExceptionManager loadWrapperExceptionWithUUIDString:[self uuidRefToString:report.uuidRef]];
   if (wrapperException) {
     errorLog.exception = wrapperException.modelException;
   }
@@ -304,21 +300,14 @@ static const char *findSEL(const char *imageName, NSString *imageUUID, uint64_t 
   NSString *signal = errorLog.osExceptionType;
   NSString *exceptionReason = errorLog.exceptionReason;
   NSString *exceptionName = errorLog.exceptionType;
-
-  /*
-   * errorlog.toffset represents the timestamp when the app crashed, appLaunchTOffset is the difference/offset between
-   * the moment the app was launched and when the app crashed.
-   */
-  NSDate *appStartTime = [NSDate
-      dateWithTimeIntervalSince1970:(([errorLog.toffset doubleValue] - [errorLog.appLaunchTOffset doubleValue]) /
-                                     1000)];
-  NSDate *appErrorTime = [NSDate dateWithTimeIntervalSince1970:([errorLog.toffset doubleValue] / 1000)];
+  NSDate *appStartTime = errorLog.appLaunchTimestamp;
+  NSDate *appErrorTime = errorLog.timestamp;
 
   // Retrieve the process' id.
   NSUInteger processId = [errorLog.processId unsignedIntegerValue];
 
   // Retrieve the device that correlates with the time of a crash.
-  MSDevice *device = [[MSDeviceTracker sharedInstance] deviceForToffset:errorLog.toffset];
+  MSDevice *device = [[MSDeviceTracker sharedInstance] deviceForTimestamp:errorLog.timestamp];
 
   // Finally create the MSErrorReport instance.
   errorReport = [[MSErrorReport alloc] initWithErrorId:errorId
@@ -379,24 +368,12 @@ static const char *findSEL(const char *imageName, NSString *imageUUID, uint64_t 
   return errorLog;
 }
 
-+ (NSNumber *)calculateAppLaunchTOffsetFromReport:(MSPLCrashReport *)report {
-  NSDate *crashTime = report.systemInfo.timestamp;
-  NSTimeInterval difference;
-  if (report.processInfo) {
-    NSDate *startTime = report.processInfo.processStartTime;
-    difference = ([crashTime timeIntervalSinceDate:startTime] * 1000);
-  } else {
-
-    // Use difference between now and crashtime as appLaunchTOffset as fallback.
-    difference = ([[NSDate date] timeIntervalSinceDate:crashTime] * 1000);
-  }
-  return @(difference);
++ (NSDate *)getAppLaunchTimeFromReport:(MSPLCrashReport *)report {
+  return report.processInfo ? report.processInfo.processStartTime : report.systemInfo.timestamp;
 }
 
-+ (NSNumber *)calculateTOffsetFromReport:(MSPLCrashReport *)report {
-  NSDate *crashTime = report.systemInfo.timestamp;
-  long long difference = (long long)([crashTime timeIntervalSince1970] * 1000);
-  return @(difference);
++ (NSDate *)getCrashTimeFromReport:(MSPLCrashReport *)report {
+  return report.systemInfo.timestamp;
 }
 
 + (NSArray<MSThread *> *)extractThreadsFromReport:(MSPLCrashReport *)report
@@ -650,7 +627,8 @@ static const char *findSEL(const char *imageName, NSString *imageUUID, uint64_t 
     NSString *regexPattern = @"(/Users/[^/]+/)";
     NSRegularExpression *regex = [NSRegularExpression regularExpressionWithPattern:regexPattern options:0 error:&error];
     if (!regex) {
-      MSLogError([MSCrashes logTag], @"Couldn't create regular expression with pattern\"%@\": %@", regexPattern, error.localizedDescription);
+      MSLogError([MSCrashes logTag], @"Couldn't create regular expression with pattern\"%@\": %@", regexPattern,
+                 error.localizedDescription);
       return anonymizedProcessPath;
     }
     anonymizedProcessPath = [regex stringByReplacingMatchesInString:path

--- a/MobileCenterCrashes/MobileCenterCrashesTests/MSAppleErrorLogTests.m
+++ b/MobileCenterCrashes/MobileCenterCrashesTests/MSAppleErrorLogTests.m
@@ -51,7 +51,7 @@
   appleLog.errorThreadId = @2;
   appleLog.errorThreadName = @"2";
   appleLog.fatal = YES;
-  appleLog.appLaunchTOffset = @123;
+  appleLog.appLaunchTimestamp = [NSDate dateWithTimeIntervalSince1970:42];
   appleLog.architecture = @"test";
 
   return appleLog;
@@ -84,7 +84,7 @@
   assertThat(actual[@"error_thread_id"], equalTo(self.sut.errorThreadId));
   assertThat(actual[@"error_thread_name"], equalTo(self.sut.errorThreadName));
   XCTAssertEqual([actual[@"fatal"] boolValue], self.sut.fatal);
-  assertThat(actual[@"app_launch_toffset"], equalTo(self.sut.appLaunchTOffset));
+  assertThat(actual[@"app_launch_timestamp"], equalTo(@"1970-01-01T00:00:42Z"));
   assertThat(actual[@"architecture"], equalTo(self.sut.architecture));
 
   // Exception fields.
@@ -151,12 +151,11 @@
   log.device = OCMClassMock([MSDevice class]);
   OCMStub([log.device isValid]).andReturn(YES);
   log.sid = @"sid";
-  log.toffset = @123;
+  log.timestamp = [NSDate dateWithTimeIntervalSince1970:42];
   log.errorId = @"errorId";
   log.processId = @123;
   log.processName = @"processName";
-  log.appLaunchTOffset = @1234567;
-  log.toffset = @(1);
+  log.appLaunchTimestamp = [NSDate dateWithTimeIntervalSince1970:442];
   log.sid = MS_UUID_STRING;
 
   // Then

--- a/MobileCenterCrashes/MobileCenterCrashesTests/MSCrashesTests.mm
+++ b/MobileCenterCrashes/MobileCenterCrashesTests/MSCrashesTests.mm
@@ -582,7 +582,7 @@ static unsigned int kMaxAttachmentsPerCrashReport = 2;
   for(unsigned int i = 0; i < kMaxAttachmentsPerCrashReport + 1; ++i) {
     NSString *text = [NSString stringWithFormat:@"%d", i];
     MSErrorAttachmentLog *log = [[MSErrorAttachmentLog alloc] initWithFilename:text attachmentText:text];
-    log.toffset = [NSNumber numberWithInt:0];
+    log.timestamp = [NSDate dateWithTimeIntervalSince1970:42];
     log.device = deviceMock;
     [logs addObject:log];
   }

--- a/MobileCenterCrashes/MobileCenterCrashesTests/MSErrorAttachmentLogTests.m
+++ b/MobileCenterCrashes/MobileCenterCrashesTests/MSErrorAttachmentLogTests.m
@@ -185,7 +185,7 @@
 #pragma mark - Utility
 
 - (void)setDummyParentProperties:(MSErrorAttachmentLog *)attachment {
-  attachment.toffset = @(1);
+  attachment.timestamp = [NSDate dateWithTimeIntervalSince1970:42];
   attachment.sid = MS_UUID_STRING;
   attachment.device = OCMClassMock([MSDevice class]);
   OCMStub([attachment.device isValid]).andReturn(YES);

--- a/MobileCenterCrashes/MobileCenterCrashesTests/MSErrorLogFormatterTests.mm
+++ b/MobileCenterCrashes/MobileCenterCrashesTests/MSErrorLogFormatterTests.mm
@@ -423,15 +423,9 @@
   assertThat(errorLog.processName, equalTo(crashReport.processInfo.processName));
   assertThat(errorLog.parentProcessId, equalTo(@(crashReport.processInfo.parentProcessID)));
   assertThat(errorLog.parentProcessName, equalTo(crashReport.processInfo.parentProcessName));
-
   assertThat(errorLog.errorThreadId, equalTo(@(crashedThread.threadNumber)));
-
-  NSDate *appStartTime = [NSDate
-      dateWithTimeIntervalSince1970:(([errorLog.toffset doubleValue] - [errorLog.appLaunchTOffset doubleValue]) /
-                                     1000)];
-  NSDate *appErrorTime = [NSDate dateWithTimeIntervalSince1970:([errorLog.toffset doubleValue] / 1000)];
-  assertThat(appErrorTime, equalTo(crashReport.systemInfo.timestamp));
-  assertThat(appStartTime, equalTo(crashReport.processInfo.processStartTime));
+  assertThat(errorLog.timestamp, equalTo(crashReport.systemInfo.timestamp));
+  assertThat(errorLog.appLaunchTimestamp, equalTo(crashReport.processInfo.processStartTime));
 
   NSArray *images = crashReport.images;
   for (MSPLCrashReportBinaryImageInfo *image in images) {

--- a/MobileCenterPush/MobileCenterPushTests/MSPushLogTests.m
+++ b/MobileCenterPush/MobileCenterPushTests/MSPushLogTests.m
@@ -64,7 +64,7 @@
   // If
   self.sut.device = OCMClassMock([MSDevice class]);
   OCMStub([self.sut.device isValid]).andReturn(YES);
-  self.sut.toffset = @(3);
+  self.sut.timestamp = [NSDate dateWithTimeIntervalSince1970:42];
   self.sut.sid = @"1234567890";
 
   // Then


### PR DESCRIPTION
This PR replaces #667 by re-implementation because there are so many merge conflicts.