### PR TITLE
Exclude disablemachExceptionHandler from header for tvOS and make sur…

### DIFF
--- a/MobileCenterCrashes/MobileCenterCrashes/Internals/MSCrashesPrivate.h
+++ b/MobileCenterCrashes/MobileCenterCrashes/Internals/MSCrashesPrivate.h
@@ -70,10 +70,7 @@ typedef struct MSCrashesCallbacks {
   MSCrashesPostCrashSignalCallback handleSignal;
 } MSCrashesCallbacks;
 
-// TODO: Mach exception handler is not supported on tvOS.
-#if !TARGET_OS_TV
 @property(nonatomic, assign, getter=isMachExceptionHandlerEnabled) BOOL enableMachExceptionHandler;
-#endif
 
 /**
  * A list containing all crash files that currently stored on disk for this app.

--- a/MobileCenterCrashes/MobileCenterCrashes/MSCrashes.h
+++ b/MobileCenterCrashes/MobileCenterCrashes/MSCrashes.h
@@ -91,7 +91,6 @@ typedef NS_ENUM(NSUInteger, MSUserConfirmation) {
 /// @name Configuration
 ///-----------------------------------------------------------------------------
 
-// TODO: Mach exception handler is not supported on tvOS.
 #if !TARGET_OS_TV
 /**
  * Disable the Mach exception server.
@@ -108,7 +107,10 @@ typedef NS_ENUM(NSUInteger, MSUserConfirmation) {
  * `MSCrashes.disableMachExceptionHandler()`
  * `MSMobileCenter.start("YOUR_APP_ID", withServices: [MSAnalytics.self, MSCrashes.self])`
  *
- * @discussion This can be useful to disable the Mach exception handler when you are debugging the Crashes service while
+ * tvOS does not support the Mach exception handler, thus crashes that are caused by stack overflows cannot
+ * be detected. As a result, disabling the Mach exception server is not available in the tvOS SDK.
+ *
+ * @discussion It can be useful to disable the Mach exception handler when you are debugging the Crashes service while
  * developing, especially when you attach the debugger to your application after launch.
  */
 + (void)disableMachExceptionHandler;

--- a/MobileCenterCrashes/MobileCenterCrashes/MSCrashes.mm
+++ b/MobileCenterCrashes/MobileCenterCrashes/MSCrashes.mm
@@ -232,7 +232,7 @@ __attribute__((noreturn)) static void uncaught_cxx_exception_handler(const MSCra
 /*
  * This can never be bound to Xamarin.
  *
- * This method is not part of the publicly available on tvOS as Mach exception handling is not possible on tvOS. 
+ * This method is not part of the publicly available APIs on tvOS as Mach exception handling is not possible on tvOS. 
  * The property is NO by default there.
  */
 + (void)disableMachExceptionHandler {

--- a/MobileCenterCrashes/MobileCenterCrashes/MSCrashes.mm
+++ b/MobileCenterCrashes/MobileCenterCrashes/MSCrashes.mm
@@ -229,13 +229,15 @@ __attribute__((noreturn)) static void uncaught_cxx_exception_handler(const MSCra
   return [[self sharedInstance] getLastSessionCrashReport];
 }
 
-/* This can never be binded to Xamarin */
-// TODO: Mach exception handler is not supported on tvOS.
-#if !TARGET_OS_TV
+/*
+ * This can never be bound to Xamarin.
+ *
+ * This method is not part of the publicly available on tvOS as Mach exception handling is not possible on tvOS. 
+ * The property is NO by default there.
+ */
 + (void)disableMachExceptionHandler {
   [[self sharedInstance] setEnableMachExceptionHandler:NO];
 }
-#endif
 
 + (void)setDelegate:(_Nullable id<MSCrashesDelegate>)delegate {
   [[self sharedInstance] setDelegate:delegate];
@@ -252,7 +254,6 @@ __attribute__((noreturn)) static void uncaught_cxx_exception_handler(const MSCra
     _analyzerInProgressFile = [_crashesDir URLByAppendingPathComponent:kMSAnalyzerFilename];
     _didCrashInLastSession = NO;
 
-    // TODO: Mach exception handler is not supported on tvOS.
 #if !TARGET_OS_TV
     _enableMachExceptionHandler = YES;
 #endif
@@ -389,6 +390,10 @@ __attribute__((noreturn)) static void uncaught_cxx_exception_handler(const MSCra
 
 - (MSInitializationPriority)initializationPriority {
   return MSInitializationPriorityMax;
+}
+
+- (void)setEnableMachExceptionHandler:(BOOL)enableMachExceptionHandler {
+  _enableMachExceptionHandler = enableMachExceptionHandler;
 }
 
 #pragma mark - MSLogManagerDelegate
@@ -561,7 +566,6 @@ __attribute__((noreturn)) static void uncaught_cxx_exception_handler(const MSCra
 
   PLCrashReporterSignalHandlerType signalHandlerType = PLCrashReporterSignalHandlerTypeBSD;
 
-  // TODO: Mach exception handler is not supported on tvOS.
 #if !TARGET_OS_TV
   if (self.isMachExceptionHandlerEnabled) {
     signalHandlerType = PLCrashReporterSignalHandlerTypeMach;

--- a/MobileCenterCrashes/MobileCenterCrashesTests/MSCrashesTests.mm
+++ b/MobileCenterCrashes/MobileCenterCrashesTests/MSCrashesTests.mm
@@ -494,7 +494,7 @@ static unsigned int kMaxAttachmentsPerCrashReport = 2;
   XCTAssertTrue([[MSCrashes sharedInstance] initializationPriority] == MSInitializationPriorityMax);
 }
 
-// TODO: Mach exception handler is not supported on tvOS.
+// The Mach exception handler is not supported on tvOS.
 #if !TARGET_OS_TV
 - (void)testDisableMachExceptionWorks {
 
@@ -515,6 +515,14 @@ static unsigned int kMaxAttachmentsPerCrashReport = 2;
 
   // Then
   XCTAssertFalse([self.sut isMachExceptionHandlerEnabled]);
+}
+#endif
+
+#if TARGET_OS_TV
+- (void) testMachExceptionHandlerDisabledOnTvOS {
+  
+  // Then
+  XCTAssertFalse([[MSCrashes sharedInstance] isMachExceptionHandlerEnabled]);  
 }
 #endif
 

--- a/MobileCenterCrashes/MobileCenterCrashesTests/MSCrashesTests.mm
+++ b/MobileCenterCrashes/MobileCenterCrashesTests/MSCrashesTests.mm
@@ -495,35 +495,34 @@ static unsigned int kMaxAttachmentsPerCrashReport = 2;
 }
 
 // The Mach exception handler is not supported on tvOS.
-#if !TARGET_OS_TV
-- (void)testDisableMachExceptionWorks {
-
-  // Then
-  XCTAssertTrue([[MSCrashes sharedInstance] isMachExceptionHandlerEnabled]);
-
-  // When
-  [MSCrashes disableMachExceptionHandler];
-
-  // Then
-  XCTAssertFalse([[MSCrashes sharedInstance] isMachExceptionHandlerEnabled]);
-
-  // Then
-  XCTAssertTrue([self.sut isMachExceptionHandlerEnabled]);
-
-  // When
-  [self.sut setEnableMachExceptionHandler:NO];
-
-  // Then
-  XCTAssertFalse([self.sut isMachExceptionHandlerEnabled]);
-}
-#endif
-
 #if TARGET_OS_TV
 - (void) testMachExceptionHandlerDisabledOnTvOS {
   
   // Then
   XCTAssertFalse([[MSCrashes sharedInstance] isMachExceptionHandlerEnabled]);  
 }
+#else
+- (void)testDisableMachExceptionWorks {
+  
+  // Then
+  XCTAssertTrue([[MSCrashes sharedInstance] isMachExceptionHandlerEnabled]);
+  
+  // When
+  [MSCrashes disableMachExceptionHandler];
+  
+  // Then
+  XCTAssertFalse([[MSCrashes sharedInstance] isMachExceptionHandlerEnabled]);
+  
+  // Then
+  XCTAssertTrue([self.sut isMachExceptionHandlerEnabled]);
+  
+  // When
+  [self.sut setEnableMachExceptionHandler:NO];
+  
+  // Then
+  XCTAssertFalse([self.sut isMachExceptionHandlerEnabled]);
+}
+
 #endif
 
 - (void)testAbstractErrorLogSerialization {


### PR DESCRIPTION
…e it’s not enabled when initializing MSCrashes on tvOS.

The API won't be available in the header, but I chose to leave the internal methods in there for tvOS.