### PR TITLE
Restore executing push registration code on simulator

### DIFF
--- a/MobileCenterPush/MobileCenterPush/MSPush.m
+++ b/MobileCenterPush/MobileCenterPush/MSPush.m
@@ -262,8 +262,8 @@ static void *UserNotificationCenterDelegateContext = &UserNotificationCenterDele
 }
 
 - (void)didFailToRegisterForRemoteNotificationsWithError:(NSError *)error {
-  MSLogVerbose([MSPush logTag], @"Registering for push notifications has been finished with error: %@",
-               error.description);
+  MSLogWarning([MSPush logTag], @"Registering for push notifications has been finished with error: %@",
+               error.localizedDescription);
 }
 
 #if TARGET_OS_OSX

--- a/MobileCenterPush/MobileCenterPush/MSPush.m
+++ b/MobileCenterPush/MobileCenterPush/MSPush.m
@@ -221,8 +221,8 @@ static void *UserNotificationCenterDelegateContext = &UserNotificationCenterDele
     UNAuthorizationOptions authOptions =
         (UNAuthorizationOptions)(UNAuthorizationOptionAlert | UNAuthorizationOptionSound | UNAuthorizationOptionBadge);
     [center requestAuthorizationWithOptions:authOptions
-                          completionHandler:^(__attribute__((unused)) BOOL granted,
-                                              __attribute__((unused)) NSError *_Nullable error){
+                          completionHandler:^(__unused BOOL granted,
+                                              __unused NSError *_Nullable error) {
                           }];
 #pragma clang diagnostic pop
   }

--- a/MobileCenterPush/MobileCenterPush/MSPush.m
+++ b/MobileCenterPush/MobileCenterPush/MSPush.m
@@ -205,7 +205,7 @@ static void *UserNotificationCenterDelegateContext = &UserNotificationCenterDele
 
 #if TARGET_OS_OSX
   [NSApp registerForRemoteNotificationTypes:(NSRemoteNotificationTypeSound | NSRemoteNotificationTypeBadge)];
-#elif TARGET_OS_IOS && !TARGET_OS_SIMULATOR
+#elif TARGET_OS_IOS
   if (floor(NSFoundationVersionNumber) <= NSFoundationVersionNumber_iOS_9_x_Max) {
     UIUserNotificationType allNotificationTypes = (UIUserNotificationType)(
         UIUserNotificationTypeSound | UIUserNotificationTypeAlert | UIUserNotificationTypeBadge);

--- a/MobileCenterPush/MobileCenterPushTests/MSPushTests.m
+++ b/MobileCenterPush/MobileCenterPushTests/MSPushTests.m
@@ -1,6 +1,8 @@
 #import <Foundation/Foundation.h>
 #if TARGET_OS_OSX
 #import <AppKit/AppKit.h>
+#else
+#import <UserNotifications/UserNotifications.h>
 #endif
 #import "MSService.h"
 #import "MSServiceAbstract.h"
@@ -56,6 +58,19 @@ static NSString *const kMSTestPushToken = @"TestPushToken";
 - (void)setUp {
   [super setUp];
   self.sut = [MSPush new];
+  
+  // Mock UNUserNotificationCenter since it not supported during tests.
+#if TARGET_OS_IOS
+  if (floor(NSFoundationVersionNumber) > NSFoundationVersionNumber_iOS_9_x_Max) {
+  
+  // Ignore the partial availability warning as the compiler doesn't get that we checked for pre-iOS 10 already.
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpartial-availability"
+    id notificationCenterMock = OCMClassMock([UNUserNotificationCenter class]);
+    OCMStub(ClassMethod([notificationCenterMock currentNotificationCenter])).andReturn(nil);
+#pragma clang diagnostic pop
+  }
+#endif
 }
 
 - (void)tearDown {


### PR DESCRIPTION
There is an issue - on simulator we don't print any messages that pushes are not supported on it. This makes confused customers that don't know push specifics.

**TL;DR**
This behavior was introduced here: https://github.com/Microsoft/mobile-center-sdk-ios/commit/826deb0a1c9414f70885a4b07237ac8a8dd5aa29#diff-8a6dda2e220279e67126fd356f3f5381

This PR restore executing push registration code on simulator. Error `remote notifications are not supported in the simulator` handled carefully in `didFailToRegisterForRemoteNotificationsWithError` now. Also, logging error message was improved. Instead of
`[MobileCenterPush] VERBOSE: -[MSPush didFailToRegisterForRemoteNotificationsWithError:]/207 Registering for push notifications has been finished with error: Error Domain=NSCocoaErrorDomain Code=3010 "remote notifications are not supported in the simulator" UserInfo={NSLocalizedDescription=remote notifications are not supported in the simulator}`
customers will see
`[MobileCenterPush] WARNING: -[MSPush didFailToRegisterForRemoteNotificationsWithError:]/266 Registering for push notifications has been finished with error: remote notifications are not supported in the simulator`